### PR TITLE
rename timeslot → time_block / BookingTimeSlot → Slot

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,11 +24,10 @@ The shared outdoor Facility. Bookable as a single all-day block.
 
 **Time Block**:
 A fixed time-of-day template attached to a Facility. The Laundry Room has 5 Time Blocks (07–10, 10–13, 13–16, 16–19, 19–22); the Outdoor Area has 1 (07–22). The set is closed — changing or adding a Time Block is a real domain change. A Time Block is _not_ a date.
-_Avoid_: Timeslot (current DB name; planned rename), time window, schedule entry.
+_Avoid_: time window, schedule entry.
 
 **Slot**:
 A Time Block on a specific date — the bookable cell in the calendar UI. A Slot is either free, booked by another Apartment, or "mine". The 10–13 Time Block, taken on 2026-05-04, is one Slot.
-_Avoid_: Timeslot (ambiguous between Time Block and Slot — never use this word in domain prose).
 
 **Booking**:
 The act and record of an Apartment claiming a Slot. One Apartment may hold at most one Active Booking per Facility at a time.
@@ -103,7 +102,6 @@ _Avoid_: Username (the apartment number is the username), display username, name
 ## Flagged ambiguities
 
 - "User", "resident", and "member" were used interchangeably in early docs. Resolved: the actor is the **Apartment**. "Resident" remains acceptable in human-facing prose ("residents log in to book…") but is not a domain term in code or specs.
-- "Timeslot" was used for both the template and the calendar cell. Resolved: **Time Block** = template, **Slot** = template-on-a-date. The DB table `timeslot` is to be renamed to `time_block`; the type `BookingTimeSlot` to `Slot`. Tracked as planned work.
 - "Active" Booking was previously defined date-grain (`date >= today`), which blocked rebooking until midnight even after a Slot ended. Resolved: Active = `date + endHour > now`. The current code (`booking.ts`, `notification.ts`, `calendar.ts`) still uses the date-grain check; switching to slot-end-grain is planned work.
 - "Notification" was used for both the reminder concept and the DB tables. Resolved: domain term is **Reminder** / **Reminder Preference**. The DB tables `notification_preference` and `booking_notification`, files `notification*.ts`, and remote functions are to be renamed accordingly. Tracked as planned work.
 - "Calendar" was used for three different things: the iCal feed, the booking-page month-view UI, and (loosely) the Booking Window. Resolved: the iCal feed is the **Calendar Subscription**; the month-view is "the booking calendar UI" (not a domain term); the Booking Window is its own term. Avoid bare "Calendar" as a domain noun.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There is no self-registration. Accounts are pre-created by an admin. Each reside
 ## Features
 
 - **Closed user system** -- no self-registration; accounts are provisioned by admin for each of the 32 apartments. Username is the apartment number (e.g. A1001). Supports password reset via email, email address changes with re-verification, and customizable display names.
-- **Laundry room booking** -- calendar with 5 daily timeslots (3-hour blocks, 07-22), one active booking per user
+- **Laundry room booking** -- calendar with 5 daily 3-hour blocks (07-22), one active booking per user
 - **Outdoor area booking** -- calendar with 1 all-day slot (07-22), one active booking per user
 - **Booking constraints** -- 30-day advance window, concurrent booking protection via database unique constraint, replace-or-cancel flow
 - **Calendar subscription** -- per-user iCal feed URL (`/kalender/{token}.ics`) that syncs bookings to iPhone Calendar or any app supporting webcal subscriptions; manage from account page
@@ -63,7 +63,7 @@ src/
     server/
       db/
         auth.schema.ts         # Better Auth tables (user, session, account, verification)
-        booking.schema.ts      # Booking domain (timeslot, booking)
+        booking.schema.ts      # Booking domain (time_block, booking)
         calendar.schema.ts     # iCal subscription tokens
         notification.schema.ts # Notification preferences and scheduled reminders
         schema.ts              # Re-exports all schemas for Drizzle
@@ -96,7 +96,7 @@ src/
       Navbar.svelte            # Desktop navigation with dropdowns
       MobileMenu.svelte        # Slide-out mobile navigation
       BookingPage.svelte       # Shared layout for laundry/outdoor booking pages
-      TimeSlots.svelte         # Time-slot grid with book/cancel/replace flow
+      Slots.svelte             # Slot grid with book/cancel/replace flow
       SetupHints.svelte        # Dismissible onboarding hints
   routes/
     +layout.svelte             # Global layout (navbar, toaster, user state)

--- a/scripts/db/reset-dev.ts
+++ b/scripts/db/reset-dev.ts
@@ -9,7 +9,7 @@ import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { PASSWORD_CONFIG, usernamePlugin } from '../../src/lib/server/auth.config.js';
 import { user } from '../../src/lib/server/db/auth.schema.js';
-import { booking, timeslot } from '../../src/lib/server/db/booking.schema.js';
+import { booking, timeBlock } from '../../src/lib/server/db/booking.schema.js';
 import * as schema from '../../src/lib/server/db/schema.js';
 
 const databaseUrl = process.env.DATABASE_URL;
@@ -88,7 +88,7 @@ const DEV_NAMES = [
 	'Mikael Fransson'
 ];
 
-const TIMESLOT_SEEDS = [
+const TIME_BLOCK_SEEDS = [
 	{ startHour: 7, endHour: 10, resource: 'laundry_room' as const },
 	{ startHour: 10, endHour: 13, resource: 'laundry_room' as const },
 	{ startHour: 13, endHour: 16, resource: 'laundry_room' as const },
@@ -121,8 +121,8 @@ try {
 		plugins: [usernamePlugin()]
 	});
 
-	for (const ts of TIMESLOT_SEEDS) {
-		await db.insert(timeslot).values(ts).onConflictDoNothing();
+	for (const tb of TIME_BLOCK_SEEDS) {
+		await db.insert(timeBlock).values(tb).onConflictDoNothing();
 	}
 
 	for (let i = 0; i < APARTMENTS.length; i++) {
@@ -145,29 +145,29 @@ try {
 
 	const users = await db.select({ id: user.id, username: user.username }).from(user);
 	const userMap = new Map(users.map((u) => [u.username, u.id]));
-	const timeslots = await db.select().from(timeslot);
-	const laundrySlots = timeslots.filter((ts) => ts.resource === 'laundry_room');
-	const outdoorSlot = timeslots.find((ts) => ts.resource === 'outdoor_area');
+	const timeBlocks = await db.select().from(timeBlock);
+	const laundryBlocks = timeBlocks.filter((tb) => tb.resource === 'laundry_room');
+	const outdoorBlock = timeBlocks.find((tb) => tb.resource === 'outdoor_area');
 
 	for (const apt of APARTMENTS.slice(0, 16)) {
 		const userId = userMap.get(apt);
 		if (!userId) continue;
-		const slot = laundrySlots[randomInt(0, laundrySlots.length - 1)];
+		const block = laundryBlocks[randomInt(0, laundryBlocks.length - 1)];
 		await db
 			.insert(booking)
 			.values({
 				userId,
-				timeslotId: slot.id,
+				timeBlockId: block.id,
 				resource: 'laundry_room',
 				date: randomFutureDate()
 			})
 			.onConflictDoNothing();
-		if (outdoorSlot && Math.random() < 0.4) {
+		if (outdoorBlock && Math.random() < 0.4) {
 			await db
 				.insert(booking)
 				.values({
 					userId,
-					timeslotId: outdoorSlot.id,
+					timeBlockId: outdoorBlock.id,
 					resource: 'outdoor_area',
 					date: randomFutureDate()
 				})

--- a/scripts/db/seed-test.ts
+++ b/scripts/db/seed-test.ts
@@ -5,7 +5,7 @@ import { drizzle } from 'drizzle-orm/pglite';
 import { PGlite } from '@electric-sql/pglite';
 import { PASSWORD_CONFIG, usernamePlugin } from '../../src/lib/server/auth.config.js';
 import { user } from '../../src/lib/server/db/auth.schema.js';
-import { timeslot } from '../../src/lib/server/db/booking.schema.js';
+import { timeBlock } from '../../src/lib/server/db/booking.schema.js';
 import * as schema from '../../src/lib/server/db/schema.js';
 
 const pglitePath = process.env.PGLITE_PATH;
@@ -61,7 +61,7 @@ const DEV_NAMES = [
 	'Mikael Fransson'
 ];
 
-const TIMESLOT_SEEDS = [
+const TIME_BLOCK_SEEDS = [
 	{ startHour: 7, endHour: 10, resource: 'laundry_room' as const },
 	{ startHour: 10, endHour: 13, resource: 'laundry_room' as const },
 	{ startHour: 13, endHour: 16, resource: 'laundry_room' as const },
@@ -83,8 +83,8 @@ const seedAuth = betterAuth({
 	plugins: [usernamePlugin()]
 });
 
-for (const ts of TIMESLOT_SEEDS) {
-	await db.insert(timeslot).values(ts).onConflictDoNothing();
+for (const tb of TIME_BLOCK_SEEDS) {
+	await db.insert(timeBlock).values(tb).onConflictDoNothing();
 }
 
 for (let i = 0; i < APARTMENTS.length; i++) {

--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -6,14 +6,14 @@ import { requireAuth, getAuthUser } from '$lib/server/auth';
 import { log } from '$lib/server/log';
 import {
 	getBookingCalendar,
-	getTimeslotStartHour,
+	getTimeBlockStartHour,
 	bookSlot,
 	cancelBooking as cancelBookingDb,
 	validateBookingDate
 } from '$lib/server/booking';
 import { createBookingNotifications } from '$lib/server/notification';
 import { touchUserActivity } from '$lib/server/activity';
-import { TIMEZONE, RESOURCES, type BookingTimeSlot } from '$lib/types/bookings';
+import { TIMEZONE, RESOURCES, type Slot } from '$lib/types/bookings';
 
 const resourceSchema = v.picklist(RESOURCES);
 const calendarDateSchema = v.instance(CalendarDate);
@@ -33,26 +33,26 @@ export const getBookingData = query(
 		const zdt = now(TIMEZONE);
 		const fetchedAt = new Time(zdt.hour, zdt.minute, zdt.second);
 
-		// Extract unique timeslots (ordered by startHour from the query)
-		const timeslotSet = new Map<number, { startHour: number; endHour: number }>();
+		// Extract unique time blocks (ordered by startHour from the query)
+		const timeBlockSet = new Map<number, { startHour: number; endHour: number }>();
 		for (const row of rawRows) {
-			if (!timeslotSet.has(row.timeslotId)) {
-				timeslotSet.set(row.timeslotId, {
+			if (!timeBlockSet.has(row.timeBlockId)) {
+				timeBlockSet.set(row.timeBlockId, {
 					startHour: row.startHour,
 					endHour: row.endHour
 				});
 			}
 		}
-		const timeslots = [...timeslotSet.entries()];
+		const timeBlocks = [...timeBlockSet.entries()];
 
-		// Build a map of (date:timeslotId) -> booking info
+		// Build a map of (date:timeBlockId) -> booking info
 		const bookingMap = new Map<
 			string,
 			{ bookingId: number; userId: string; username: string | null }
 		>();
 		for (const row of rawRows) {
 			if (row.date !== null && row.bookingId !== null) {
-				bookingMap.set(`${row.date}:${row.timeslotId}`, {
+				bookingMap.set(`${row.date}:${row.timeBlockId}`, {
 					bookingId: row.bookingId,
 					userId: row.userId!,
 					username: row.username
@@ -64,23 +64,23 @@ export const getBookingData = query(
 		const start = today(TIMEZONE);
 		const end = start.add({ months: 1 });
 
-		const bookingCalendar: Record<string, BookingTimeSlot[]> = {};
-		let activeBooking: BookingTimeSlot | undefined = undefined;
+		const bookingCalendar: Record<string, Slot[]> = {};
+		let activeBooking: Slot | undefined = undefined;
 
 		let current = start;
 		while (current.compare(end) <= 0) {
 			const dateStr = current.toString();
-			const bookingsTimeSlots: BookingTimeSlot[] = [];
+			const slots: Slot[] = [];
 
-			for (const [tid, ts] of timeslots) {
+			for (const [tid, tb] of timeBlocks) {
 				const b = bookingMap.get(`${dateStr}:${tid}`);
 				const status = b === undefined ? 'free' : b.userId === user?.id ? 'mine' : 'other';
 
-				bookingsTimeSlots.push({
-					timeslotId: tid,
+				slots.push({
+					timeBlockId: tid,
 					date: current,
-					start: ts.startHour,
-					end: ts.endHour,
+					start: tb.startHour,
+					end: tb.endHour,
 					status,
 					bookingId: b?.bookingId ?? null,
 					username: user ? (b?.username ?? null) : null
@@ -88,10 +88,10 @@ export const getBookingData = query(
 
 				if (activeBooking === undefined && b !== undefined && b?.userId === user?.id) {
 					activeBooking = {
-						timeslotId: tid,
+						timeBlockId: tid,
 						date: current,
-						start: ts.startHour,
-						end: ts.endHour,
+						start: tb.startHour,
+						end: tb.endHour,
 						status,
 						bookingId: b.bookingId,
 						username: b.username
@@ -99,7 +99,7 @@ export const getBookingData = query(
 				}
 			}
 
-			bookingCalendar[dateStr] = bookingsTimeSlots;
+			bookingCalendar[dateStr] = slots;
 			current = current.add({ days: 1 });
 		}
 
@@ -109,22 +109,22 @@ export const getBookingData = query(
 
 export const book = command(
 	v.object({
-		timeslotId: v.number(),
+		timeBlockId: v.number(),
 		resource: resourceSchema,
 		date: calendarDateSchema,
 		replaceBookingId: v.optional(v.number())
 	}),
-	async ({ timeslotId, resource, date, replaceBookingId }) => {
+	async ({ timeBlockId, resource, date, replaceBookingId }) => {
 		const user = requireAuth();
 
 		const dateError = validateBookingDate(date);
 		if (dateError) error(400, VALIDATE_DATE_MESSAGES[dateError]);
 
-		const startHour = await getTimeslotStartHour(timeslotId);
+		const startHour = await getTimeBlockStartHour(timeBlockId);
 
 		const result = await bookSlot({
 			userId: user.id,
-			timeslotId,
+			timeBlockId,
 			resource,
 			date,
 			replaceBookingId
@@ -154,7 +154,7 @@ export const book = command(
 				user.id,
 				resource,
 				date.toString(),
-				timeslotId
+				timeBlockId
 			);
 		} catch (e) {
 			log.warn(

--- a/src/lib/components/BookingPage.svelte
+++ b/src/lib/components/BookingPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import SetupHints from '$lib/components/SetupHints.svelte';
 	import Calendar from '$lib/components/Calendar.svelte';
-	import TimeSlots from '$lib/components/TimeSlots.svelte';
+	import Slots from '$lib/components/Slots.svelte';
 	import { getOptionalUser } from '$lib/api/auth.remote';
 	import { getSetupHints } from '$lib/api/hints.remote';
 	import { getBookingData } from '$lib/api/booking.remote';
@@ -31,7 +31,7 @@
 	let slotCount = $derived(laundryRoom ? 5 : 1);
 	let bookingCalendar = $derived(data.bookingCalendar);
 	let activeBooking = $derived(data.activeBooking);
-	let timeslots = $derived(bookingCalendar[date.toString()] ?? []);
+	let slots = $derived(bookingCalendar[date.toString()] ?? []);
 
 	// TODO: replace polling with SSE once $derived(await ...) + .refresh() is stable
 	// poll for booking changes and refresh when the page becomes visible after being hidden
@@ -110,4 +110,4 @@
 </div>
 
 <!-- time slots -->
-<TimeSlots {resource} {date} {timeslots} {activeBooking} />
+<Slots {resource} {date} {slots} {activeBooking} />

--- a/src/lib/components/Calendar.svelte
+++ b/src/lib/components/Calendar.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
 	import { Calendar } from 'bits-ui';
 	import { type CalendarDate, type DateValue } from '@internationalized/date';
-	import { type BookingTimeSlot, type BookingTimeSlotStatus } from '$lib/types/bookings';
+	import { type Slot, type SlotStatus } from '$lib/types/bookings';
 	import { formatMonth } from '$lib/utils/date';
 
 	interface Props {
 		date: CalendarDate;
 		minValue: CalendarDate;
 		maxValue: CalendarDate;
-		bookingCalendar: Record<string, BookingTimeSlot[]>;
+		bookingCalendar: Record<string, Slot[]>;
 		slotCount: number;
 	}
 
 	let { date = $bindable(), minValue, maxValue, bookingCalendar }: Props = $props();
 
-	const statusColorMap: Record<BookingTimeSlotStatus, string> = {
+	const statusColorMap: Record<SlotStatus, string> = {
 		free: 'border border-border',
 		mine: 'bg-slot-mine',
 		other: 'bg-slot-occupied'
@@ -84,9 +84,8 @@
 										>
 											{day.day}
 											<div class="mt-0.5 flex gap-0.5">
-												{#each bookingCalendar[day.toString()] as timeslot (timeslot.start)}
-													<span class="box-border size-1.5 {statusColorMap[timeslot.status]}"
-													></span>
+												{#each bookingCalendar[day.toString()] as slot (slot.start)}
+													<span class="box-border size-1.5 {statusColorMap[slot.status]}"></span>
 												{/each}
 											</div>
 										</Calendar.Day>

--- a/src/lib/components/Slots.svelte
+++ b/src/lib/components/Slots.svelte
@@ -4,17 +4,17 @@
 	import { getBookingData, book, cancelBooking } from '$lib/api/booking.remote';
 	import { getOptionalUser } from '$lib/api/auth.remote';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
-	import { type BookingTimeSlot, type Resource } from '$lib/types/bookings';
+	import { type Slot, type Resource } from '$lib/types/bookings';
 	import { formatDate, formatHourNumShort } from '$lib/utils/date';
 
 	interface Props {
 		resource: Resource;
 		date: CalendarDate;
-		timeslots: BookingTimeSlot[];
-		activeBooking: BookingTimeSlot | undefined;
+		slots: Slot[];
+		activeBooking: Slot | undefined;
 	}
 
-	let { resource, date, timeslots, activeBooking }: Props = $props();
+	let { resource, date, slots, activeBooking }: Props = $props();
 
 	// load data
 	let user = $derived(await getOptionalUser());
@@ -23,13 +23,13 @@
 	let error = $state('');
 	let cancelBookingId = $state<number | null>(null);
 	let pendingBooking = $state<{
-		timeslotId: number;
+		timeBlockId: number;
 		replaceBookingId: number;
 		replaceDescription: string;
 	} | null>(null);
 	let showLoginDialog = $state(false);
 
-	async function handleSlotClick(slot: BookingTimeSlot) {
+	async function handleSlotClick(slot: Slot) {
 		if (!user) {
 			showLoginDialog = true;
 			return;
@@ -37,14 +37,14 @@
 		error = '';
 		if (activeBooking) {
 			pendingBooking = {
-				timeslotId: slot.timeslotId,
+				timeBlockId: slot.timeBlockId,
 				replaceBookingId: activeBooking.bookingId!,
 				replaceDescription: `${formatDate(activeBooking.date)}, ${formatHourNumShort(activeBooking.start)}–${formatHourNumShort(activeBooking.end)}`
 			};
 			return;
 		}
 		try {
-			await book({ timeslotId: slot.timeslotId, resource, date });
+			await book({ timeBlockId: slot.timeBlockId, resource, date });
 			toast.success('Bokning lyckades!');
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
@@ -68,7 +68,7 @@
 		error = '';
 		try {
 			await book({
-				timeslotId: pendingBooking.timeslotId,
+				timeBlockId: pendingBooking.timeBlockId,
 				resource,
 				date,
 				replaceBookingId: pendingBooking.replaceBookingId
@@ -82,7 +82,7 @@
 </script>
 
 <div class="grid grid-cols-5 gap-2">
-	{#each timeslots as slot (slot.timeslotId)}
+	{#each slots as slot (slot.timeBlockId)}
 		{@const timeRange = `${formatHourNumShort(slot.start)}–${formatHourNumShort(slot.end)}`}
 		{#if slot.status === 'free'}
 			<button

--- a/src/lib/server/booking.ts
+++ b/src/lib/server/booking.ts
@@ -1,7 +1,7 @@
 import { type CalendarDate, today } from '@internationalized/date';
 import { eq, and, gte, lte } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { booking, timeslot, user } from '$lib/server/db/schema';
+import { booking, timeBlock, user } from '$lib/server/db/schema';
 import { TIMEZONE, type Resource } from '$lib/types/bookings';
 
 const PG_UNIQUE_VIOLATION = '23505';
@@ -10,11 +10,11 @@ function isUniqueViolation(e: unknown): boolean {
 	return e instanceof Error && 'code' in e && e.code === PG_UNIQUE_VIOLATION;
 }
 
-export async function getTimeslotStartHour(timeslotId: number): Promise<number | null> {
+export async function getTimeBlockStartHour(timeBlockId: number): Promise<number | null> {
 	const [row] = await db
-		.select({ startHour: timeslot.startHour })
-		.from(timeslot)
-		.where(eq(timeslot.id, timeslotId))
+		.select({ startHour: timeBlock.startHour })
+		.from(timeBlock)
+		.where(eq(timeBlock.id, timeBlockId))
 		.limit(1);
 	return row?.startHour ?? null;
 }
@@ -38,27 +38,27 @@ export async function getBookingCalendar(resource: Resource) {
 
 	return await db
 		.select({
-			timeslotId: timeslot.id,
-			startHour: timeslot.startHour,
-			endHour: timeslot.endHour,
+			timeBlockId: timeBlock.id,
+			startHour: timeBlock.startHour,
+			endHour: timeBlock.endHour,
 			date: booking.date,
 			bookingId: booking.id,
 			userId: booking.userId,
 			username: user.username
 		})
-		.from(timeslot)
+		.from(timeBlock)
 		.leftJoin(
 			booking,
 			and(
-				eq(booking.timeslotId, timeslot.id),
+				eq(booking.timeBlockId, timeBlock.id),
 				eq(booking.resource, resource),
 				gte(booking.date, startDate),
 				lte(booking.date, endDate)
 			)
 		)
 		.leftJoin(user, eq(booking.userId, user.id))
-		.where(eq(timeslot.resource, resource))
-		.orderBy(timeslot.startHour);
+		.where(eq(timeBlock.resource, resource))
+		.orderBy(timeBlock.startHour);
 }
 
 type BookSlotResult =
@@ -79,7 +79,7 @@ class BookSlotConflict extends Error {
 
 export async function bookSlot(params: {
 	userId: string;
-	timeslotId: number;
+	timeBlockId: number;
 	resource: Resource;
 	date: CalendarDate;
 	replaceBookingId?: number;
@@ -99,10 +99,10 @@ export async function bookSlot(params: {
 					.select({
 						resource: booking.resource,
 						date: booking.date,
-						startHour: timeslot.startHour
+						startHour: timeBlock.startHour
 					})
 					.from(booking)
-					.innerJoin(timeslot, eq(booking.timeslotId, timeslot.id))
+					.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 					.where(
 						and(
 							eq(booking.id, params.replaceBookingId),
@@ -148,7 +148,7 @@ export async function bookSlot(params: {
 					.insert(booking)
 					.values({
 						userId: params.userId,
-						timeslotId: params.timeslotId,
+						timeBlockId: params.timeBlockId,
 						resource: params.resource,
 						date: params.date.toString()
 					})
@@ -175,10 +175,10 @@ export async function cancelBooking(
 		.select({
 			resource: booking.resource,
 			date: booking.date,
-			startHour: timeslot.startHour
+			startHour: timeBlock.startHour
 		})
 		.from(booking)
-		.innerJoin(timeslot, eq(booking.timeslotId, timeslot.id))
+		.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 		.where(and(eq(booking.id, bookingId), eq(booking.userId, userId), gte(booking.date, todayStr)))
 		.limit(1);
 	if (!info) return null;

--- a/src/lib/server/calendar.ts
+++ b/src/lib/server/calendar.ts
@@ -3,7 +3,7 @@ import { eq, and, gte } from 'drizzle-orm';
 import { today } from '@internationalized/date';
 import ical, { ICalCalendarMethod } from 'ical-generator';
 import { db } from '$lib/server/db';
-import { booking, timeslot, calendarToken } from '$lib/server/db/schema';
+import { booking, timeBlock, calendarToken } from '$lib/server/db/schema';
 import { TIMEZONE } from '$lib/types/bookings';
 
 const RESOURCE_LABELS = {
@@ -63,11 +63,11 @@ export async function generateCalendarFeed(userId: string): Promise<string> {
 			bookingId: booking.id,
 			resource: booking.resource,
 			date: booking.date,
-			startHour: timeslot.startHour,
-			endHour: timeslot.endHour
+			startHour: timeBlock.startHour,
+			endHour: timeBlock.endHour
 		})
 		.from(booking)
-		.innerJoin(timeslot, eq(booking.timeslotId, timeslot.id))
+		.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 		.where(and(eq(booking.userId, userId), gte(booking.date, todayStr)));
 
 	const cal = ical({

--- a/src/lib/server/db/booking.schema.ts
+++ b/src/lib/server/db/booking.schema.ts
@@ -21,8 +21,8 @@ type _AssertResourceMatch = (typeof resourceEnum.enumValues)[number] extends Res
 		: never
 	: never;
 
-export const timeslot = pgTable(
-	'timeslot',
+export const timeBlock = pgTable(
+	'time_block',
 	{
 		id: serial('id').primaryKey(),
 		startHour: integer('start_hour').notNull(),
@@ -30,7 +30,7 @@ export const timeslot = pgTable(
 		resource: resourceEnum().notNull()
 	},
 	(table) => [
-		unique('timeslot_hours_resource_unique').on(table.startHour, table.endHour, table.resource)
+		unique('time_block_hours_resource_unique').on(table.startHour, table.endHour, table.resource)
 	]
 );
 
@@ -41,14 +41,18 @@ export const booking = pgTable(
 		userId: text('user_id')
 			.notNull()
 			.references(() => user.id, { onDelete: 'cascade' }),
-		timeslotId: integer('timeslot_id')
+		timeBlockId: integer('time_block_id')
 			.notNull()
-			.references(() => timeslot.id),
+			.references(() => timeBlock.id),
 		resource: resourceEnum().notNull(),
 		date: date('date').notNull(),
 		createdAt: timestamp('created_at').defaultNow().notNull()
 	},
 	(table) => [
-		unique('booking_resource_timeslot_date_unique').on(table.resource, table.timeslotId, table.date)
+		unique('booking_resource_time_block_date_unique').on(
+			table.resource,
+			table.timeBlockId,
+			table.date
+		)
 	]
 );

--- a/src/lib/server/notification.scheduler.ts
+++ b/src/lib/server/notification.scheduler.ts
@@ -6,7 +6,7 @@ import { log } from '$lib/server/log';
 import { sendEmail } from '$lib/server/email';
 import { EMAIL_TEMPLATES } from '$lib/server/email.templates';
 import { bookingNotification } from '$lib/server/db/notification.schema';
-import { booking, timeslot } from '$lib/server/db/booking.schema';
+import { booking, timeBlock } from '$lib/server/db/booking.schema';
 import { user } from '$lib/server/db/auth.schema';
 import { buildBookingReminderVariables } from '$lib/server/notification.email';
 
@@ -20,13 +20,13 @@ export async function processNotifications(): Promise<number> {
 			username: user.username,
 			resource: booking.resource,
 			date: booking.date,
-			startHour: timeslot.startHour,
-			endHour: timeslot.endHour
+			startHour: timeBlock.startHour,
+			endHour: timeBlock.endHour
 		})
 		.from(bookingNotification)
 		.innerJoin(user, eq(bookingNotification.userId, user.id))
 		.innerJoin(booking, eq(bookingNotification.bookingId, booking.id))
-		.innerJoin(timeslot, eq(booking.timeslotId, timeslot.id))
+		.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 		.where(
 			and(eq(bookingNotification.status, 'pending'), lte(bookingNotification.notifyAt, currentTime))
 		)

--- a/src/lib/server/notification.ts
+++ b/src/lib/server/notification.ts
@@ -3,7 +3,7 @@ import { eq, and, gte, inArray } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { log } from '$lib/server/log';
 import { notificationPreference, bookingNotification } from '$lib/server/db/notification.schema';
-import { booking, timeslot } from '$lib/server/db/booking.schema';
+import { booking, timeBlock } from '$lib/server/db/booking.schema';
 import { user } from '$lib/server/db/auth.schema';
 import { TIMEZONE, type Resource } from '$lib/types/bookings';
 
@@ -62,10 +62,10 @@ export async function setNotificationPreference(
 				.select({
 					bookingId: booking.id,
 					date: booking.date,
-					startHour: timeslot.startHour
+					startHour: timeBlock.startHour
 				})
 				.from(booking)
-				.innerJoin(timeslot, eq(booking.timeslotId, timeslot.id))
+				.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 				.where(
 					and(
 						eq(booking.userId, userId),
@@ -121,14 +121,14 @@ export async function createBookingNotifications(
 	userId: string,
 	resource: Resource,
 	dateStr: string,
-	timeslotId: number
+	timeBlockId: number
 ) {
-	const [slot] = await db
-		.select({ startHour: timeslot.startHour })
-		.from(timeslot)
-		.where(eq(timeslot.id, timeslotId));
+	const [block] = await db
+		.select({ startHour: timeBlock.startHour })
+		.from(timeBlock)
+		.where(eq(timeBlock.id, timeBlockId));
 
-	if (!slot) return;
+	if (!block) return;
 
 	const prefs = await db
 		.select({ offsetMinutes: notificationPreference.offsetMinutes })
@@ -142,7 +142,7 @@ export async function createBookingNotifications(
 		);
 
 	for (const pref of prefs) {
-		const notifyAt = computeNotifyAt(dateStr, slot.startHour, pref.offsetMinutes);
+		const notifyAt = computeNotifyAt(dateStr, block.startHour, pref.offsetMinutes);
 		await db
 			.insert(bookingNotification)
 			.values({
@@ -157,7 +157,7 @@ export async function createBookingNotifications(
 	if (prefs.length > 0) {
 		const username = await lookupUsername(userId);
 		log.info(
-			`[notification] created ${prefs.length} reminder(s) username=${username} resource=${resource} date=${dateStr} startHour=${slot.startHour}`
+			`[notification] created ${prefs.length} reminder(s) username=${username} resource=${resource} date=${dateStr} startHour=${block.startHour}`
 		);
 	}
 }

--- a/src/lib/types/bookings.ts
+++ b/src/lib/types/bookings.ts
@@ -4,14 +4,14 @@ export const TIMEZONE = 'Europe/Stockholm';
 export const RESOURCES = ['laundry_room', 'outdoor_area'] as const;
 export type Resource = (typeof RESOURCES)[number];
 
-export type BookingTimeSlotStatus = 'free' | 'mine' | 'other';
+export type SlotStatus = 'free' | 'mine' | 'other';
 
-export type BookingTimeSlot = {
-	timeslotId: number;
+export type Slot = {
+	timeBlockId: number;
 	date: CalendarDate;
 	start: number;
 	end: number;
-	status: BookingTimeSlotStatus;
+	status: SlotStatus;
 	bookingId: number | null;
 	username: string | null;
 };


### PR DESCRIPTION
## Summary

End-to-end rename across the booking subsystem to match the resolved CONTEXT.md vocabulary: **Time Block** (template) vs **Slot** (date-bound calendar cell). Schema, types, server logic, remote API, components, seeds, and docs all updated in one coherent pass.

Disambiguation was done per-reference, not mass find-replace. Sets of template IDs become `timeBlockSet`; arrays of date-bound cells become `slots`; the iCal join target is `time_block`; etc.

Closes #4.

## Changes

- **Schema** (`booking.schema.ts`): `timeslot` table → `time_block`; column `timeslot_id` → `time_block_id`; both unique constraints renamed.
- **Types** (`bookings.ts`): `BookingTimeSlot` → `Slot`, `BookingTimeSlotStatus` → `SlotStatus`, `timeslotId` field → `timeBlockId`.
- **Server** (`booking.ts`, `calendar.ts`, `notification.ts`, `notification.scheduler.ts`): table refs `timeslot` → `timeBlock`; `getTimeslotStartHour` → `getTimeBlockStartHour`; the local `slot` row from the time_block table in `createBookingNotifications` is now `block`.
- **Remote API** (`booking.remote.ts`): `book` mutation parameter `timeslotId` → `timeBlockId`.
- **Components**: git-renamed `TimeSlots.svelte` → `Slots.svelte`; prop `timeslots` → `slots`; loop variable in `Calendar.svelte` renamed.
- **Seeds**: `TIMESLOT_SEEDS` → `TIME_BLOCK_SEEDS`; loop locals reclassified.
- **Docs**: README copy updated; resolved "timeslot" entry removed from CONTEXT.md Flagged Ambiguities.

## Migration

**Operator must run `pnpm db:push` against prod immediately before merge** from an interactive terminal and answer "rename" at each of the four drizzle-kit prompts:

1. Table `timeslot` → `time_block`
2. Column `booking.timeslot_id` → `booking.time_block_id`
3. Constraint `timeslot_hours_resource_unique` → `time_block_hours_resource_unique`
4. Constraint `booking_resource_timeslot_date_unique` → `booking_resource_time_block_date_unique`

Dev DB has already been pushed and verified.

## Test plan

- [x] `rg -i 'timeslot' src/ scripts/ README.md CONTEXT.md` returns zero hits
- [x] `pnpm check` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (15 unit + 34 e2e; 2 SSE skips pre-existing) — no test assertions modified
- [x] Prod `pnpm db:push` answered "rename" at each prompt
- [x] Smoke test: booking calendar loads; book → cancel → rebook a different slot; iCal feed renders