### PR TITLE
refactor: extract buildBookingPayload helper

### DIFF
--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -1,5 +1,5 @@
 import * as v from 'valibot';
-import { CalendarDate, Time, now, today } from '@internationalized/date';
+import { CalendarDate, Time, now } from '@internationalized/date';
 import { error } from '@sveltejs/kit';
 import { query, command, requested } from '$app/server';
 import { requireAuth, getAuthUser } from '$lib/server/auth';
@@ -8,12 +8,13 @@ import {
 	getBookingCalendar,
 	getTimeBlockStartHour,
 	bookSlot,
+	buildBookingPayload,
 	cancelBooking as cancelBookingDb,
 	validateBookingDate
 } from '$lib/server/booking';
 import { createBookingNotifications } from '$lib/server/notification';
 import { touchUserActivity } from '$lib/server/activity';
-import { TIMEZONE, RESOURCES, type Slot } from '$lib/types/bookings';
+import { TIMEZONE, RESOURCES } from '$lib/types/bookings';
 
 const resourceSchema = v.picklist(RESOURCES);
 const calendarDateSchema = v.instance(CalendarDate);
@@ -33,75 +34,7 @@ export const getBookingData = query(
 		const zdt = now(TIMEZONE);
 		const fetchedAt = new Time(zdt.hour, zdt.minute, zdt.second);
 
-		// Extract unique time blocks (ordered by startHour from the query)
-		const timeBlockSet = new Map<number, { startHour: number; endHour: number }>();
-		for (const row of rawRows) {
-			if (!timeBlockSet.has(row.timeBlockId)) {
-				timeBlockSet.set(row.timeBlockId, {
-					startHour: row.startHour,
-					endHour: row.endHour
-				});
-			}
-		}
-		const timeBlocks = [...timeBlockSet.entries()];
-
-		// Build a map of (date:timeBlockId) -> booking info
-		const bookingMap = new Map<
-			string,
-			{ bookingId: number; userId: string; username: string | null }
-		>();
-		for (const row of rawRows) {
-			if (row.date !== null && row.bookingId !== null) {
-				bookingMap.set(`${row.date}:${row.timeBlockId}`, {
-					bookingId: row.bookingId,
-					userId: row.userId!,
-					username: row.username
-				});
-			}
-		}
-
-		// Generate calendar for each day in range
-		const start = today(TIMEZONE);
-		const end = start.add({ months: 1 });
-
-		const bookingCalendar: Record<string, Slot[]> = {};
-		let activeBooking: Slot | undefined = undefined;
-
-		let current = start;
-		while (current.compare(end) <= 0) {
-			const dateStr = current.toString();
-			const slots: Slot[] = [];
-
-			for (const [tid, tb] of timeBlocks) {
-				const b = bookingMap.get(`${dateStr}:${tid}`);
-				const status = b === undefined ? 'free' : b.userId === user?.id ? 'mine' : 'other';
-
-				slots.push({
-					timeBlockId: tid,
-					date: current,
-					start: tb.startHour,
-					end: tb.endHour,
-					status,
-					bookingId: b?.bookingId ?? null,
-					username: user ? (b?.username ?? null) : null
-				});
-
-				if (activeBooking === undefined && b !== undefined && b?.userId === user?.id) {
-					activeBooking = {
-						timeBlockId: tid,
-						date: current,
-						start: tb.startHour,
-						end: tb.endHour,
-						status,
-						bookingId: b.bookingId,
-						username: b.username
-					};
-				}
-			}
-
-			bookingCalendar[dateStr] = slots;
-			current = current.add({ days: 1 });
-		}
+		const { bookingCalendar, activeBooking } = buildBookingPayload(rawRows, user);
 
 		return { bookingCalendar, activeBooking, fetchedAt };
 	}

--- a/src/lib/server/booking.spec.ts
+++ b/src/lib/server/booking.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { today } from '@internationalized/date';
 import { TIMEZONE } from '$lib/types/bookings';
-import { validateBookingDate } from './booking';
+import { buildBookingPayload, validateBookingDate, type BookingCalendarRow } from './booking';
 
 describe('validateBookingDate', () => {
 	const now = today(TIMEZONE);
@@ -24,5 +24,283 @@ describe('validateBookingDate', () => {
 
 	it('returns "too_far" for more than one month from now', () => {
 		expect(validateBookingDate(now.add({ months: 1, days: 1 }))).toBe('too_far');
+	});
+});
+
+describe('buildBookingPayload', () => {
+	const me = { id: 'apt-A1001' };
+	const someoneElse = { id: 'apt-B2002' };
+	const start = today(TIMEZONE);
+	const end = start.add({ months: 1 });
+	const startStr = start.toString();
+	const endStr = end.toString();
+
+	function expectedDateStrings(): string[] {
+		const dates: string[] = [];
+		let d = start;
+		while (d.compare(end) <= 0) {
+			dates.push(d.toString());
+			d = d.add({ days: 1 });
+		}
+		return dates;
+	}
+
+	it('returns an empty slot array per day in the Booking Window when there are no time blocks', () => {
+		const { bookingCalendar, activeBooking } = buildBookingPayload([], me);
+
+		const dates = expectedDateStrings();
+		expect(Object.keys(bookingCalendar).sort()).toEqual([...dates].sort());
+		for (const d of dates) {
+			expect(bookingCalendar[d]).toEqual([]);
+		}
+		expect(activeBooking).toBeUndefined();
+	});
+
+	it('marks every Slot free when no Apartment has booked anything', () => {
+		const rows: BookingCalendarRow[] = [
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			}
+		];
+
+		const { bookingCalendar, activeBooking } = buildBookingPayload(rows, me);
+
+		const dates = expectedDateStrings();
+		for (const d of dates) {
+			expect(bookingCalendar[d]).toHaveLength(1);
+			const slot = bookingCalendar[d][0];
+			expect(slot.status).toBe('free');
+			expect(slot.bookingId).toBeNull();
+			expect(slot.username).toBeNull();
+			expect(slot.start).toBe(7);
+			expect(slot.end).toBe(10);
+			expect(slot.timeBlockId).toBe(1);
+		}
+		expect(activeBooking).toBeUndefined();
+	});
+
+	it('tags the calling Apartment\'s Slot as "mine" and surfaces it as activeBooking', () => {
+		const rows: BookingCalendarRow[] = [
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			},
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: startStr,
+				bookingId: 42,
+				userId: me.id,
+				username: 'A1001'
+			}
+		];
+
+		const { bookingCalendar, activeBooking } = buildBookingPayload(rows, me);
+
+		const todaySlot = bookingCalendar[startStr][0];
+		expect(todaySlot.status).toBe('mine');
+		expect(todaySlot.bookingId).toBe(42);
+		expect(todaySlot.username).toBe('A1001');
+
+		expect(activeBooking).toBeDefined();
+		expect(activeBooking?.bookingId).toBe(42);
+		expect(activeBooking?.status).toBe('mine');
+		expect(activeBooking?.date.toString()).toBe(startStr);
+	});
+
+	it('picks the earliest Slot as activeBooking when the Apartment has multiple Bookings in the rows', () => {
+		const laterStr = start.add({ days: 5 }).toString();
+		const rows: BookingCalendarRow[] = [
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: laterStr,
+				bookingId: 99,
+				userId: me.id,
+				username: 'A1001'
+			},
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: startStr,
+				bookingId: 42,
+				userId: me.id,
+				username: 'A1001'
+			}
+		];
+
+		const { activeBooking } = buildBookingPayload(rows, me);
+
+		expect(activeBooking?.bookingId).toBe(42);
+		expect(activeBooking?.date.toString()).toBe(startStr);
+	});
+
+	it('tags another Apartment\'s Slot as "other" and exposes their username to a signed-in caller', () => {
+		const rows: BookingCalendarRow[] = [
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: startStr,
+				bookingId: 7,
+				userId: someoneElse.id,
+				username: 'B2002'
+			}
+		];
+
+		const { bookingCalendar, activeBooking } = buildBookingPayload(rows, me);
+
+		const slot = bookingCalendar[startStr][0];
+		expect(slot.status).toBe('other');
+		expect(slot.bookingId).toBe(7);
+		expect(slot.username).toBe('B2002');
+		expect(activeBooking).toBeUndefined();
+	});
+
+	it('hides usernames from anonymous callers but still tags Slots as "other"', () => {
+		const rows: BookingCalendarRow[] = [
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: startStr,
+				bookingId: 7,
+				userId: someoneElse.id,
+				username: 'B2002'
+			}
+		];
+
+		const { bookingCalendar, activeBooking } = buildBookingPayload(rows, null);
+
+		const slot = bookingCalendar[startStr][0];
+		expect(slot.status).toBe('other');
+		expect(slot.bookingId).toBe(7);
+		expect(slot.username).toBeNull();
+		expect(activeBooking).toBeUndefined();
+	});
+
+	it('covers every day from today through today + 1 month and reflects bookings at both ends of the Window', () => {
+		const midStr = start.add({ days: 7 }).toString();
+		const rows: BookingCalendarRow[] = [
+			// Five laundry-room time blocks — emit one row per block as the "no booking" baseline
+			{
+				timeBlockId: 1,
+				startHour: 7,
+				endHour: 10,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			},
+			{
+				timeBlockId: 2,
+				startHour: 10,
+				endHour: 13,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			},
+			{
+				timeBlockId: 3,
+				startHour: 13,
+				endHour: 16,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			},
+			{
+				timeBlockId: 4,
+				startHour: 16,
+				endHour: 19,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			},
+			{
+				timeBlockId: 5,
+				startHour: 19,
+				endHour: 22,
+				date: null,
+				bookingId: null,
+				userId: null,
+				username: null
+			},
+			// Today: another Apartment claimed the 10–13 Slot
+			{
+				timeBlockId: 2,
+				startHour: 10,
+				endHour: 13,
+				date: startStr,
+				bookingId: 100,
+				userId: someoneElse.id,
+				username: 'B2002'
+			},
+			// One week in: the calling Apartment booked 13–16
+			{
+				timeBlockId: 3,
+				startHour: 13,
+				endHour: 16,
+				date: midStr,
+				bookingId: 101,
+				userId: me.id,
+				username: 'A1001'
+			},
+			// Far end of the window: another Apartment booked 19–22
+			{
+				timeBlockId: 5,
+				startHour: 19,
+				endHour: 22,
+				date: endStr,
+				bookingId: 102,
+				userId: someoneElse.id,
+				username: 'B2002'
+			}
+		];
+
+		const { bookingCalendar, activeBooking } = buildBookingPayload(rows, me);
+
+		const dates = expectedDateStrings();
+		expect(Object.keys(bookingCalendar)).toHaveLength(dates.length);
+		expect(bookingCalendar[startStr]).toBeDefined();
+		expect(bookingCalendar[endStr]).toBeDefined();
+
+		for (const d of dates) {
+			expect(bookingCalendar[d]).toHaveLength(5);
+			expect(bookingCalendar[d].map((s) => s.start)).toEqual([7, 10, 13, 16, 19]);
+		}
+
+		const todaySlots = bookingCalendar[startStr];
+		expect(todaySlots[0].status).toBe('free');
+		expect(todaySlots[1].status).toBe('other');
+		expect(todaySlots[1].bookingId).toBe(100);
+		expect(todaySlots[1].username).toBe('B2002');
+
+		const midSlots = bookingCalendar[midStr];
+		expect(midSlots[2].status).toBe('mine');
+		expect(midSlots[2].bookingId).toBe(101);
+
+		const endSlots = bookingCalendar[endStr];
+		expect(endSlots[4].status).toBe('other');
+		expect(endSlots[4].bookingId).toBe(102);
+
+		expect(activeBooking?.bookingId).toBe(101);
+		expect(activeBooking?.date.toString()).toBe(midStr);
 	});
 });

--- a/src/lib/server/booking.ts
+++ b/src/lib/server/booking.ts
@@ -2,7 +2,7 @@ import { type CalendarDate, today } from '@internationalized/date';
 import { eq, and, gte, lte } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { booking, timeBlock, user } from '$lib/server/db/schema';
-import { TIMEZONE, type Resource } from '$lib/types/bookings';
+import { TIMEZONE, type Resource, type Slot } from '$lib/types/bookings';
 
 const PG_UNIQUE_VIOLATION = '23505';
 
@@ -32,7 +32,17 @@ export function validateBookingDate(date: CalendarDate): ValidateBookingDateErro
 	return null;
 }
 
-export async function getBookingCalendar(resource: Resource) {
+export type BookingCalendarRow = {
+	timeBlockId: number;
+	startHour: number;
+	endHour: number;
+	date: string | null;
+	bookingId: number | null;
+	userId: string | null;
+	username: string | null;
+};
+
+export async function getBookingCalendar(resource: Resource): Promise<BookingCalendarRow[]> {
 	const startDate = today(TIMEZONE).toString();
 	const endDate = maxBookingDate().toString();
 
@@ -59,6 +69,80 @@ export async function getBookingCalendar(resource: Resource) {
 		.leftJoin(user, eq(booking.userId, user.id))
 		.where(eq(timeBlock.resource, resource))
 		.orderBy(timeBlock.startHour);
+}
+
+export function buildBookingPayload(
+	rawRows: BookingCalendarRow[],
+	user: { id: string } | null
+): { bookingCalendar: Record<string, Slot[]>; activeBooking: Slot | undefined } {
+	const timeBlockSet = new Map<number, { startHour: number; endHour: number }>();
+	for (const row of rawRows) {
+		if (!timeBlockSet.has(row.timeBlockId)) {
+			timeBlockSet.set(row.timeBlockId, {
+				startHour: row.startHour,
+				endHour: row.endHour
+			});
+		}
+	}
+	const timeBlocks = [...timeBlockSet.entries()];
+
+	const bookingMap = new Map<
+		string,
+		{ bookingId: number; userId: string; username: string | null }
+	>();
+	for (const row of rawRows) {
+		if (row.date !== null && row.bookingId !== null) {
+			bookingMap.set(`${row.date}:${row.timeBlockId}`, {
+				bookingId: row.bookingId,
+				userId: row.userId!,
+				username: row.username
+			});
+		}
+	}
+
+	const start = today(TIMEZONE);
+	const end = start.add({ months: 1 });
+
+	const bookingCalendar: Record<string, Slot[]> = {};
+	let activeBooking: Slot | undefined = undefined;
+
+	let current = start;
+	while (current.compare(end) <= 0) {
+		const dateStr = current.toString();
+		const slots: Slot[] = [];
+
+		for (const [tid, tb] of timeBlocks) {
+			const b = bookingMap.get(`${dateStr}:${tid}`);
+			const status = b === undefined ? 'free' : b.userId === user?.id ? 'mine' : 'other';
+
+			slots.push({
+				timeBlockId: tid,
+				date: current,
+				start: tb.startHour,
+				end: tb.endHour,
+				status,
+				bookingId: b?.bookingId ?? null,
+				username: user ? (b?.username ?? null) : null
+			});
+
+			if (activeBooking === undefined && b !== undefined && b.userId === user?.id) {
+				activeBooking = {
+					timeBlockId: tid,
+					date: current,
+					start: tb.startHour,
+					end: tb.endHour,
+					status,
+					bookingId: b.bookingId,
+					username: b.username
+				};
+			}
+		}
+
+		bookingCalendar[dateStr] = slots;
+		current = current.add({ days: 1 });
+	}
+
+	return { bookingCalendar, activeBooking };
 }
 
 type BookSlotResult =


### PR DESCRIPTION
## Summary

- Extracts the `rawRows → (bookingCalendar, activeBooking)` transformation from `getBookingData` into an exported pure helper `buildBookingPayload(rawRows, user)` in `src/lib/server/booking.ts`.
- Adds unit tests in the prior-art `validateBookingDate` style: empty rows, no bookings, the caller's own Booking (`'mine'` tagging + `activeBooking` extraction), another Apartment's Booking (`'other'` + username exposure rules for signed-in vs. anonymous callers), and a fixture spanning the full Booking Window.
- No user-visible behaviour change. `fetchedAt` continues to be computed in `getBookingData` itself — its removal is the follow-up issue (#6).

Closes #7. Sets up the clean seam #6 needs for `query.live`.

## Test plan

- [x] `pnpm test` — 22 unit + 34 E2E pass (2 SSE-refresh tests remain `.skip`, owned by #6)
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint` — clean
- [x] `pnpm knip` — clean