### PR TITLE
refactor: rewrite server logs in domain-prose form

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -18,15 +18,19 @@ const handleBetterAuth: Handle = async ({ event, resolve }) => {
 
 	const response = await svelteKitHandler({ event, resolve, auth, building });
 
-	const userId = event.locals.user?.id;
+	const sessionUser = event.locals.user;
 	const method = event.request.method;
 	const isMutation = method !== 'GET' && method !== 'HEAD';
-	if (userId && isMutation && response.status < 400) {
+	if (sessionUser && isMutation && response.status < 400) {
 		void db
 			.update(user)
 			.set({ lastActiveAt: new Date() })
-			.where(eq(user.id, userId))
-			.catch((e) => log.warn(`[activity] failed to bump lastActiveAt userId=${userId}: ${e}`));
+			.where(eq(user.id, sessionUser.id))
+			.catch((e) =>
+				log.warn(
+					`[activity] failed to update last-active timestamp for apartment ${sessionUser.username}: ${e}`
+				)
+			);
 	}
 
 	return response;

--- a/src/lib/api/admin.remote.ts
+++ b/src/lib/api/admin.remote.ts
@@ -75,7 +75,7 @@ export const updateUserName = form(
 		name: v.pipe(v.string(), v.minLength(1), v.maxLength(100))
 	}),
 	async ({ username, name }) => {
-		requireAdmin();
+		const self = requireAdmin();
 		const target = await findByUsername(username);
 		if (!target) error(404, 'Hittade inte lägenheten');
 
@@ -89,7 +89,7 @@ export const updateUserName = form(
 			if (e instanceof APIError) invalid('Kunde inte byta namn');
 			throw e;
 		}
-		log.info(`[admin] name changed username=${username}`);
+		log.info(`[admin] apartment ${self.username} changed display name for apartment ${username}`);
 	}
 );
 
@@ -99,7 +99,7 @@ export const updateUserEmail = form(
 		email: v.pipe(v.string(), v.email('Ogiltig e-postadress'))
 	}),
 	async ({ username, email }) => {
-		requireAdmin();
+		const self = requireAdmin();
 		const target = await findByUsername(username);
 		if (!target) error(404, 'Hittade inte lägenheten');
 
@@ -113,21 +113,23 @@ export const updateUserEmail = form(
 			if (e instanceof APIError) invalid('Kunde inte byta e-post');
 			throw e;
 		}
-		log.info(`[admin] email changed username=${username}`);
+		log.info(`[admin] apartment ${self.username} changed email for apartment ${username}`);
 	}
 );
 
 export const sendPasswordResetForUser = command(
 	v.object({ username: apartmentSchema }),
 	async ({ username }) => {
-		requireAdmin();
+		const self = requireAdmin();
 		const target = await findByUsername(username);
 		if (!target) error(404, 'Hittade inte lägenheten');
 
 		await auth.api.requestPasswordReset({
 			body: { email: target.email, redirectTo: '/konto/aterstall-losenord' }
 		});
-		log.info(`[admin] password reset email sent username=${username}`);
+		log.info(
+			`[admin] apartment ${self.username} sent a password reset email to apartment ${username}`
+		);
 		return { email: target.email };
 	}
 );
@@ -148,7 +150,8 @@ export const setUserRole = command(
 			body: { userId: target.id, role },
 			headers: request.headers
 		});
-		log.info(`[admin] role changed username=${username} role=${role}`);
+		const verb = role === 'admin' ? 'granted admin role to' : 'revoked admin role from';
+		log.info(`[admin] apartment ${self.username} ${verb} apartment ${username}`);
 	}
 );
 
@@ -160,11 +163,15 @@ export const setUserReminderPreference = command(
 		enabled: v.boolean()
 	}),
 	async ({ username, resource, offsetMinutes, enabled }) => {
-		requireAdmin();
+		const self = requireAdmin();
 		const target = await findByUsername(username);
 		if (!target) error(404, 'Hittade inte lägenheten');
 
 		await setReminderPreference(target.id, resource, offsetMinutes, enabled);
+		const verb = enabled ? 'enabled' : 'disabled';
+		log.info(
+			`[admin] apartment ${self.username} ${verb} ${offsetMinutes}-minute reminders for the ${resource} for apartment ${username}`
+		);
 	}
 );
 

--- a/src/lib/api/auth.remote.ts
+++ b/src/lib/api/auth.remote.ts
@@ -37,8 +37,8 @@ export const login = form(
 			});
 		} catch (e) {
 			if (e instanceof APIError) {
-				const reason = e.status === 403 ? 'email_not_verified' : 'invalid_credentials';
-				log.warn(`[auth] login failed username=${username} reason=${reason}`);
+				const reason = e.status === 403 ? 'email not verified' : 'invalid credentials';
+				log.warn(`[auth] login failed for ${username} (${reason})`);
 				if (e.status === 403) {
 					invalid('Verifiera din e-postadress innan du loggar in');
 				} else {
@@ -47,14 +47,15 @@ export const login = form(
 			}
 			throw e;
 		}
-		log.info(`[auth] login username=${username}`);
+		log.info(`[auth] apartment ${username} logged in`);
 		redirect(303, '/konto');
 	}
 );
 
 export const signout = form(async () => {
 	const { request, locals } = getRequestEvent();
-	log.info(`[auth] signout username=${locals.user?.username}`);
+	const username = locals.user?.username ?? '<unknown>';
+	log.info(`[auth] apartment ${username} logged out`);
 	await auth.api.signOut({ headers: request.headers });
 	redirect(303, '/konto/logga-in');
 });
@@ -83,7 +84,7 @@ export const requestPasswordReset = form(
 		} catch (e) {
 			// Always redirect to prevent username enumeration, but surface the failure
 			// so Resend/DB/Better Auth outages aren't hidden behind the success page.
-			log.error(`[auth] password reset failed username=${username}`, e);
+			log.error(`[auth] password reset failed for ${username}`, e);
 		}
 		redirect(303, '/konto/glomt-losenord/skickat');
 	}
@@ -110,7 +111,7 @@ export const resetPassword = form(
 			}
 			throw e;
 		}
-		log.info('[auth] password reset completed');
+		log.info('[auth] completed password reset');
 		redirect(303, '/konto/logga-in');
 	}
 );
@@ -134,7 +135,7 @@ export const changePassword = form(
 			}
 			throw e;
 		}
-		log.info(`[auth] password changed username=${user.username}`);
+		log.info(`[auth] apartment ${user.username} changed their password`);
 	}
 );
 
@@ -156,7 +157,7 @@ export const changeName = form(
 			}
 			throw e;
 		}
-		log.info(`[auth] name changed username=${user.username}`);
+		log.info(`[auth] apartment ${user.username} changed their display name`);
 	}
 );
 
@@ -178,6 +179,6 @@ export const changeEmail = form(
 			}
 			throw e;
 		}
-		log.info(`[auth] email change requested username=${user.username}`);
+		log.info(`[auth] apartment ${user.username} requested an email change`);
 	}
 );

--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -4,6 +4,7 @@ import { error } from '@sveltejs/kit';
 import { query, command, requested } from '$app/server';
 import { requireAuth, getAuthUser } from '$lib/server/auth';
 import { log } from '$lib/server/log';
+import { slotPhrase } from '$lib/server/log.prose';
 import {
 	getBookingCalendar,
 	getTimeBlockStartHour,
@@ -67,31 +68,36 @@ export const book = command(
 		if (result.kind === 'already_booked') error(409, 'Du har redan en kommande bokning');
 		if (result.kind === 'slot_taken') {
 			log.warn(
-				`[booking] conflict username=${user.username} resource=${resource} date=${date} startHour=${startHour}`
+				`[booking] apartment ${user.username} tried to book ${slotPhrase(resource, date.toString(), startHour!)} but the slot was already taken`
 			);
 			error(409, 'Tiden är redan bokad');
 		}
 
+		const newSlot = slotPhrase(resource, date.toString(), startHour!);
 		if (result.cancelled) {
 			log.info(
-				`[booking] cancelled username=${user.username} resource=${result.cancelled.resource} date=${result.cancelled.date} startHour=${result.cancelled.startHour}`
+				`[booking] apartment ${user.username} moved their ${resource} booking from ${slotPhrase(result.cancelled.resource, result.cancelled.date, result.cancelled.startHour)} to ${newSlot}`
 			);
+		} else {
+			log.info(`[booking] apartment ${user.username} booked ${newSlot}`);
 		}
-		log.info(
-			`[booking] created username=${user.username} resource=${resource} date=${date} startHour=${startHour}`
-		);
 
 		try {
-			await createBookingReminders(
+			const count = await createBookingReminders(
 				result.booking.id,
 				user.id,
 				resource,
 				date.toString(),
 				timeBlockId
 			);
+			if (count > 0) {
+				log.info(
+					`[reminder] scheduled ${count} reminder(s) for apartment ${user.username} ahead of ${newSlot}`
+				);
+			}
 		} catch (e) {
 			log.warn(
-				`[reminder] failed to create reminders username=${user.username} resource=${resource} date=${date} startHour=${startHour}: ${e}`
+				`[reminder] failed to schedule reminders for apartment ${user.username} ahead of ${newSlot}: ${e}`
 			);
 		}
 
@@ -108,7 +114,7 @@ export const cancelBooking = command(v.object({ bookingId: v.number() }), async 
 		error(404, 'Bokningen hittades inte');
 	}
 	log.info(
-		`[booking] cancelled username=${user.username} resource=${result.resource} date=${result.date} startHour=${result.startHour}`
+		`[booking] apartment ${user.username} cancelled their booking of ${slotPhrase(result.resource, result.date, result.startHour)}`
 	);
 
 	await requested(getBookingData, 5).refreshAll();

--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -4,7 +4,7 @@ import { error } from '@sveltejs/kit';
 import { query, command, requested } from '$app/server';
 import { requireAuth, getAuthUser } from '$lib/server/auth';
 import { log } from '$lib/server/log';
-import { slotPhrase } from '$lib/server/log.prose';
+import { slotPhrase, slotTimeRange } from '$lib/server/log.prose';
 import {
 	getBookingCalendar,
 	getTimeBlockStartHour,
@@ -75,8 +75,14 @@ export const book = command(
 
 		const newSlot = slotPhrase(resource, date.toString(), startHour!);
 		if (result.cancelled) {
+			const fromRange = slotTimeRange(
+				result.cancelled.resource,
+				result.cancelled.date,
+				result.cancelled.startHour
+			);
+			const toRange = slotTimeRange(resource, date.toString(), startHour!);
 			log.info(
-				`[booking] apartment ${user.username} moved their ${resource} booking from ${slotPhrase(result.cancelled.resource, result.cancelled.date, result.cancelled.startHour)} to ${newSlot}`
+				`[booking] apartment ${user.username} moved their ${resource} booking from ${fromRange} to ${toRange}`
 			);
 		} else {
 			log.info(`[booking] apartment ${user.username} booked ${newSlot}`);

--- a/src/lib/api/calendar.remote.ts
+++ b/src/lib/api/calendar.remote.ts
@@ -1,6 +1,7 @@
 import { query, command } from '$app/server';
 import { env } from '$env/dynamic/private';
 import { requireAuth } from '$lib/server/auth';
+import { log } from '$lib/server/log';
 import { getExistingToken, createToken, regenerateToken, deleteToken } from '$lib/server/calendar';
 
 function buildCalendarUrl(token: string): string {
@@ -16,16 +17,19 @@ export const getCalendarUrl = query(async () => {
 export const createCalendarUrl = command(async () => {
 	const user = requireAuth();
 	const token = await createToken(user.id);
+	log.info(`[calendar] apartment ${user.username} created their calendar subscription`);
 	return buildCalendarUrl(token);
 });
 
 export const regenerateCalendarUrl = command(async () => {
 	const user = requireAuth();
 	const token = await regenerateToken(user.id);
+	log.info(`[calendar] apartment ${user.username} regenerated their calendar subscription URL`);
 	return buildCalendarUrl(token);
 });
 
 export const deleteCalendarUrl = command(async () => {
 	const user = requireAuth();
 	await deleteToken(user.id);
+	log.info(`[calendar] apartment ${user.username} removed their calendar subscription`);
 });

--- a/src/lib/api/reminder.remote.ts
+++ b/src/lib/api/reminder.remote.ts
@@ -1,6 +1,7 @@
 import * as v from 'valibot';
 import { query, command } from '$app/server';
 import { requireAuth } from '$lib/server/auth';
+import { log } from '$lib/server/log';
 import { getReminderPreferences, setReminderPreference } from '$lib/server/reminder';
 import { RESOURCES } from '$lib/types/bookings';
 
@@ -18,5 +19,9 @@ export const togglePreference = command(
 	async ({ resource, offsetMinutes, enabled }) => {
 		const user = requireAuth();
 		await setReminderPreference(user.id, resource, offsetMinutes, enabled);
+		const verb = enabled ? 'enabled' : 'disabled';
+		log.info(
+			`[reminder] apartment ${user.username} ${verb} ${offsetMinutes}-minute reminders for the ${resource}`
+		);
 	}
 );

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -80,8 +80,14 @@ export const auth = betterAuth({
 							.set({ lastActiveAt: new Date() })
 							.where(eq(user.id, session.userId));
 					} catch (e) {
+						const [row] = await db
+							.select({ username: user.username })
+							.from(user)
+							.where(eq(user.id, session.userId))
+							.limit(1);
+						const username = row?.username ?? '<unknown>';
 						log.warn(
-							`[activity] failed to bump lastActiveAt on login userId=${session.userId}: ${e}`
+							`[activity] failed to update last-active timestamp on login for apartment ${username}: ${e}`
 						);
 					}
 				}

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -8,7 +8,7 @@ export async function sendEmail(options: {
 	templateAlias: string;
 	variables: Record<string, string | number>;
 }): Promise<string | null> {
-	const label = `to ${options.to} template=${options.templateAlias}`;
+	const label = `${options.templateAlias} to ${options.to}`;
 
 	if (!env.RESEND_API_KEY) {
 		const recipient = options.to.toLowerCase().replace(/[@.]/g, '-');

--- a/src/lib/server/log.prose.spec.ts
+++ b/src/lib/server/log.prose.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { slotPhrase } from './log.prose';
+
+describe('slotPhrase', () => {
+	const date = '2026-05-04';
+
+	it('renders Laundry Room 07-10', () => {
+		expect(slotPhrase('laundry_room', date, 7)).toBe('the laundry_room 2026-05-04 07:00-10:00');
+	});
+
+	it('renders Laundry Room 10-13', () => {
+		expect(slotPhrase('laundry_room', date, 10)).toBe('the laundry_room 2026-05-04 10:00-13:00');
+	});
+
+	it('renders Laundry Room 13-16', () => {
+		expect(slotPhrase('laundry_room', date, 13)).toBe('the laundry_room 2026-05-04 13:00-16:00');
+	});
+
+	it('renders Laundry Room 16-19', () => {
+		expect(slotPhrase('laundry_room', date, 16)).toBe('the laundry_room 2026-05-04 16:00-19:00');
+	});
+
+	it('renders Laundry Room 19-22', () => {
+		expect(slotPhrase('laundry_room', date, 19)).toBe('the laundry_room 2026-05-04 19:00-22:00');
+	});
+
+	it('renders Outdoor Area 07-22', () => {
+		expect(slotPhrase('outdoor_area', date, 7)).toBe('the outdoor_area 2026-05-04 07:00-22:00');
+	});
+
+	it('throws on unknown start hour', () => {
+		expect(() => slotPhrase('laundry_room', date, 8)).toThrow();
+	});
+});

--- a/src/lib/server/log.prose.spec.ts
+++ b/src/lib/server/log.prose.spec.ts
@@ -1,34 +1,46 @@
 import { describe, it, expect } from 'vitest';
-import { slotPhrase } from './log.prose';
+import { slotPhrase, slotTimeRange } from './log.prose';
+
+describe('slotTimeRange', () => {
+	const date = '2026-05-04';
+
+	it('renders Laundry Room 07-10', () => {
+		expect(slotTimeRange('laundry_room', date, 7)).toBe('2026-05-04 07:00-10:00');
+	});
+
+	it('renders Laundry Room 10-13', () => {
+		expect(slotTimeRange('laundry_room', date, 10)).toBe('2026-05-04 10:00-13:00');
+	});
+
+	it('renders Laundry Room 13-16', () => {
+		expect(slotTimeRange('laundry_room', date, 13)).toBe('2026-05-04 13:00-16:00');
+	});
+
+	it('renders Laundry Room 16-19', () => {
+		expect(slotTimeRange('laundry_room', date, 16)).toBe('2026-05-04 16:00-19:00');
+	});
+
+	it('renders Laundry Room 19-22', () => {
+		expect(slotTimeRange('laundry_room', date, 19)).toBe('2026-05-04 19:00-22:00');
+	});
+
+	it('renders Outdoor Area 07-22', () => {
+		expect(slotTimeRange('outdoor_area', date, 7)).toBe('2026-05-04 07:00-22:00');
+	});
+
+	it('throws on unknown start hour', () => {
+		expect(() => slotTimeRange('laundry_room', date, 8)).toThrow();
+	});
+});
 
 describe('slotPhrase', () => {
 	const date = '2026-05-04';
 
-	it('renders Laundry Room 07-10', () => {
-		expect(slotPhrase('laundry_room', date, 7)).toBe('the laundry_room 2026-05-04 07:00-10:00');
-	});
-
-	it('renders Laundry Room 10-13', () => {
+	it('prepends "the <resource>" to the time range', () => {
 		expect(slotPhrase('laundry_room', date, 10)).toBe('the laundry_room 2026-05-04 10:00-13:00');
 	});
 
-	it('renders Laundry Room 13-16', () => {
-		expect(slotPhrase('laundry_room', date, 13)).toBe('the laundry_room 2026-05-04 13:00-16:00');
-	});
-
-	it('renders Laundry Room 16-19', () => {
-		expect(slotPhrase('laundry_room', date, 16)).toBe('the laundry_room 2026-05-04 16:00-19:00');
-	});
-
-	it('renders Laundry Room 19-22', () => {
-		expect(slotPhrase('laundry_room', date, 19)).toBe('the laundry_room 2026-05-04 19:00-22:00');
-	});
-
-	it('renders Outdoor Area 07-22', () => {
+	it('renders Outdoor Area with full prefix', () => {
 		expect(slotPhrase('outdoor_area', date, 7)).toBe('the outdoor_area 2026-05-04 07:00-22:00');
-	});
-
-	it('throws on unknown start hour', () => {
-		expect(() => slotPhrase('laundry_room', date, 8)).toThrow();
 	});
 });

--- a/src/lib/server/log.prose.ts
+++ b/src/lib/server/log.prose.ts
@@ -1,0 +1,30 @@
+import type { Resource } from '$lib/types/bookings';
+
+const TIME_BLOCKS: Record<Resource, ReadonlyArray<readonly [number, number]>> = {
+	laundry_room: [
+		[7, 10],
+		[10, 13],
+		[13, 16],
+		[16, 19],
+		[19, 22]
+	],
+	outdoor_area: [[7, 22]]
+};
+
+function pad2(n: number): string {
+	return n.toString().padStart(2, '0');
+}
+
+// Renders a Slot in the canonical prose form used in server logs:
+// "the laundry_room 2026-05-04 10:00-13:00". End-hour is resolved from the
+// Facility's Time Block table rather than passed in, so call sites carry the
+// (resource, date, startHour) trio they already have. Snake_case enum values
+// stay literal — see ADR-0003.
+export function slotPhrase(resource: Resource, date: string, startHour: number): string {
+	const block = TIME_BLOCKS[resource].find(([s]) => s === startHour);
+	if (!block) {
+		throw new Error(`unknown time block for ${resource} startHour=${startHour}`);
+	}
+	const [start, end] = block;
+	return `the ${resource} ${date} ${pad2(start)}:00-${pad2(end)}:00`;
+}

--- a/src/lib/server/log.prose.ts
+++ b/src/lib/server/log.prose.ts
@@ -15,16 +15,22 @@ function pad2(n: number): string {
 	return n.toString().padStart(2, '0');
 }
 
-// Renders a Slot in the canonical prose form used in server logs:
-// "the laundry_room 2026-05-04 10:00-13:00". End-hour is resolved from the
-// Facility's Time Block table rather than passed in, so call sites carry the
-// (resource, date, startHour) trio they already have. Snake_case enum values
-// stay literal — see ADR-0003.
-export function slotPhrase(resource: Resource, date: string, startHour: number): string {
+// Renders the date + time range of a Slot — "2026-05-04 10:00-13:00". The
+// end-hour is resolved from the Facility's Time Block table rather than
+// passed in, so call sites carry the (resource, date, startHour) trio they
+// already have.
+export function slotTimeRange(resource: Resource, date: string, startHour: number): string {
 	const block = TIME_BLOCKS[resource].find(([s]) => s === startHour);
 	if (!block) {
 		throw new Error(`unknown time block for ${resource} startHour=${startHour}`);
 	}
 	const [start, end] = block;
-	return `the ${resource} ${date} ${pad2(start)}:00-${pad2(end)}:00`;
+	return `${date} ${pad2(start)}:00-${pad2(end)}:00`;
+}
+
+// Renders a Slot in the canonical prose form used in server logs:
+// "the laundry_room 2026-05-04 10:00-13:00". Snake_case enum values stay
+// literal — see ADR-0003.
+export function slotPhrase(resource: Resource, date: string, startHour: number): string {
+	return `the ${resource} ${slotTimeRange(resource, date, startHour)}`;
 }

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -43,7 +43,7 @@ export function checkRateLimit(name: string, max: number, windowSeconds: number)
 
 	if (bucket.count >= max) {
 		const retryAfter = Math.ceil((bucket.resetAt - now) / 1000);
-		log.warn(`[rate-limit] ${name} exceeded ip=${ip} retryAfter=${retryAfter}s`);
+		log.warn(`[rate-limit] ${name} exceeded for IP ${ip}, retry after ${retryAfter}s`);
 		return retryAfter;
 	}
 

--- a/src/lib/server/reminder.scheduler.ts
+++ b/src/lib/server/reminder.scheduler.ts
@@ -3,6 +3,7 @@ import { TIMEZONE } from '$lib/types/bookings';
 import { eq, and, lte } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { log } from '$lib/server/log';
+import { slotPhrase } from '$lib/server/log.prose';
 import { sendEmail } from '$lib/server/email';
 import { EMAIL_TEMPLATES } from '$lib/server/email.templates';
 import { bookingReminder } from '$lib/server/db/reminder.schema';
@@ -50,7 +51,7 @@ export async function processReminders(): Promise<number> {
 				.set({ status: 'sent', sentAt: currentTime, resendId })
 				.where(eq(bookingReminder.id, reminder.id));
 			log.info(
-				`[scheduler] sent reminder username=${reminder.username} resource=${reminder.resource} date=${reminder.date} startHour=${reminder.startHour} to=${reminder.email}`
+				`[scheduler] sent reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour)}`
 			);
 		} catch (e) {
 			const failReason = e instanceof Error ? e.message : String(e);
@@ -59,7 +60,7 @@ export async function processReminders(): Promise<number> {
 				.set({ status: 'failed', failReason })
 				.where(eq(bookingReminder.id, reminder.id));
 			log.error(
-				`[scheduler] failed reminder username=${reminder.username} resource=${reminder.resource} date=${reminder.date} startHour=${reminder.startHour}: ${failReason}`
+				`[scheduler] failed to send reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour)}: ${failReason}`
 			);
 		}
 	}
@@ -68,7 +69,7 @@ export async function processReminders(): Promise<number> {
 }
 
 export function startScheduler(): void {
-	log.info('[scheduler] reminder scheduler started (interval: 60s)');
+	log.info('[scheduler] started (interval 60s)');
 
 	processReminders().catch((e) => {
 		log.error('[scheduler] initial run failed', e);

--- a/src/lib/server/reminder.ts
+++ b/src/lib/server/reminder.ts
@@ -1,20 +1,9 @@
 import { CalendarDateTime, parseDate, toZoned, today } from '@internationalized/date';
 import { eq, and, gte, inArray } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { log } from '$lib/server/log';
 import { reminderPreference, bookingReminder } from '$lib/server/db/reminder.schema';
 import { booking, timeBlock } from '$lib/server/db/booking.schema';
-import { user } from '$lib/server/db/auth.schema';
 import { TIMEZONE, type Resource } from '$lib/types/bookings';
-
-async function lookupUsername(userId: string): Promise<string | null> {
-	const [row] = await db
-		.select({ username: user.username })
-		.from(user)
-		.where(eq(user.id, userId))
-		.limit(1);
-	return row?.username ?? null;
-}
 
 export function computeNotifyAt(dateStr: string, startHour: number, offsetMinutes: number): Date {
 	const date = parseDate(dateStr);
@@ -109,11 +98,6 @@ export async function setReminderPreference(
 				);
 		}
 	});
-
-	const username = await lookupUsername(userId);
-	log.info(
-		`[reminder] preference set username=${username} resource=${resource} offset=${offsetMinutes} enabled=${enabled}`
-	);
 }
 
 export async function createBookingReminders(
@@ -122,13 +106,13 @@ export async function createBookingReminders(
 	resource: Resource,
 	dateStr: string,
 	timeBlockId: number
-) {
+): Promise<number> {
 	const [block] = await db
 		.select({ startHour: timeBlock.startHour })
 		.from(timeBlock)
 		.where(eq(timeBlock.id, timeBlockId));
 
-	if (!block) return;
+	if (!block) return 0;
 
 	const prefs = await db
 		.select({ offsetMinutes: reminderPreference.offsetMinutes })
@@ -154,10 +138,5 @@ export async function createBookingReminders(
 			.onConflictDoNothing();
 	}
 
-	if (prefs.length > 0) {
-		const username = await lookupUsername(userId);
-		log.info(
-			`[reminder] created ${prefs.length} reminder(s) username=${username} resource=${resource} date=${dateStr} startHour=${block.startHour}`
-		);
-	}
+	return prefs.length;
 }


### PR DESCRIPTION
Closes #19. Implements ADR-0003 (`docs/adr/0003-prose-logs.md`).

## Summary
- Rewrites the 33 existing log call sites as natural-language sentences in CONTEXT.md vocabulary. Domain-event logs name the Apartment as the subject (`[booking] apartment A1001 booked the laundry_room 2026-05-04 10:00-13:00`); operational logs (scheduler, rate-limit, internal failures) take an action-first form.
- Adds a pure phrasing helper `slotPhrase(resource, date, startHour)` that resolves the Slot's end-hour from the Facility's Time Block table (Laundry Room: 5 blocks, Outdoor Area: 1 block). Lives at `src/lib/server/log.prose.ts`.
- Booking Replacement is one `moved their <facility> booking from <slot> to <slot>` line instead of the old cancelled+created pair.
- Calendar Subscription gains create / regenerate / remove lifecycle logs; iCal-feed fetches stay unlogged.
- Failed-login subject is the bare claimed identifier, not `apartment X` (avoids crediting an unauthenticated brute-forcer with an identity).
- Activity-failure resolves Apartment via `event.locals.user.username` (per-request) and a DB lookup (session-create) instead of opaque `userId`.
- Admin operations name both Admin Apartment (actor) and target apartment.
- Reminder-preference logging moved out of `setReminderPreference` so the user vs. admin actor is named correctly at each call site.

## Test plan
- [x] `pnpm test:unit` — 39 passed (incl. 7 new `slotPhrase` tests covering every Time Block + the unknown-startHour throw).
- [x] `pnpm test` — full e2e + unit run; all green except one unrelated flake (`auth flow › change display name`) that passed on retry.
- [x] `pnpm check`, `pnpm lint`, `pnpm knip` — clean.
- [x] No existing test asserts log strings.