### PR TITLE
fix(e2e): bake storage states serially to avoid PGlite write contention

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -37,10 +37,10 @@ export default async function globalSetup() {
 
 		const browser = await chromium.launch();
 		try {
-			// Batch the bakes: full parallelism chokes free CI runners on PGlite's
-			// single-writer queue. 4 keeps the temp server responsive while still
-			// being meaningfully faster than serial.
-			const BATCH = 4;
+			// Bake serially: even 4-way parallelism queues on PGlite's single
+			// writer hard enough to blow the 60s waitForURL on 2-vCPU GitHub
+			// runners. Issue #22 tracks skipping HTTP login entirely.
+			const BATCH = 1;
 			for (let i = 0; i < APARTMENTS.length; i += BATCH) {
 				const batch = APARTMENTS.slice(i, i + BATCH);
 				await Promise.all(batch.map((u) => bakeStorageState(browser, server.url, u)));


### PR DESCRIPTION
## Summary

- Drop `BATCH` from 4 to 1 in `e2e/global-setup.ts` so the 32 storage-state bakes run serially.
- 4-way parallel logins serialise on PGlite's single-writer queue under 2-vCPU CI load, regularly blowing the 60s `page.waitForURL('/konto')` and failing global setup (4 of last 5 main failures).
- Comment updated to point at #22 (the principled fix: skip HTTP login, write session rows + signed cookies directly).

Closes #21.

## Test plan

- [x] `pnpm test:e2e` locally — full E2E run completes in ~48s (well under the ~3-minute budget)
- [x] `pnpm test` (unit + E2E) — all 34 E2E + unit tests pass
- [x] Ten consecutive CI runs of `pnpm test:e2e` complete without a global-setup `waitForURL` timeout