### PR TITLE
fix: invalidate setup hints after calendar-token mutations

### DIFF
--- a/src/lib/api/calendar.remote.ts
+++ b/src/lib/api/calendar.remote.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/private';
 import { requireAuth } from '$lib/server/auth';
 import { log } from '$lib/server/log';
 import { getExistingToken, createToken, regenerateToken, deleteToken } from '$lib/server/calendar';
+import { getSetupHints } from '$lib/api/hints.remote';
 
 function buildCalendarUrl(token: string): string {
 	return `${env.ORIGIN}/kalender/${token}.ics`;
@@ -18,6 +19,7 @@ export const createCalendarUrl = command(async () => {
 	const user = requireAuth();
 	const token = await createToken(user.id);
 	log.info(`[calendar] apartment ${user.username} created their calendar subscription`);
+	await getSetupHints().refresh();
 	return buildCalendarUrl(token);
 });
 
@@ -25,6 +27,7 @@ export const regenerateCalendarUrl = command(async () => {
 	const user = requireAuth();
 	const token = await regenerateToken(user.id);
 	log.info(`[calendar] apartment ${user.username} regenerated their calendar subscription URL`);
+	await getSetupHints().refresh();
 	return buildCalendarUrl(token);
 });
 
@@ -32,4 +35,5 @@ export const deleteCalendarUrl = command(async () => {
 	const user = requireAuth();
 	await deleteToken(user.id);
 	log.info(`[calendar] apartment ${user.username} removed their calendar subscription`);
+	await getSetupHints().refresh();
 });


### PR DESCRIPTION
Closes #23

## Summary

- Calendar-token commands (`createCalendarUrl`, `regenerateCalendarUrl`, `deleteCalendarUrl`) now `await getSetupHints().refresh()` so the hints query is invalidated as part of the mutation response (single-flight server-driven refresh, the same pattern used in `booking.remote.ts`).
- The calendar hint on `/tvattstuga` and `/uteplats` now reflects the new token state on the next navigation — no hard reload needed.
- Invalidation is wired into the mutation declarations, not into pages.

## Test plan

- [x] `pnpm check` clean
- [x] `pnpm test` — full suite (34 tests) green
- [x] `e2e/setup-hints.e2e.ts` — 3 consecutive runs, all 7 tests pass without retry