### PR TITLE
fix(e2e): stabilize booking slot-count and edit-dialog clicks

### DIFF
--- a/e2e/auth.e2e.ts
+++ b/e2e/auth.e2e.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { uniqueUser, login } from './helpers';
+import { uniqueUser, login, openEditDialog } from './helpers';
 
 test.describe('auth flow', () => {
 	test('login, access protected page, sign out, login again', async ({ page }) => {
@@ -47,9 +47,7 @@ test.describe('auth flow', () => {
 		await expect(page.locator('h1')).toContainText('Hej,');
 
 		// Open the edit dialog
-		await page.getByRole('button', { name: 'Ändra' }).first().click();
-		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible();
+		const dialog = await openEditDialog(page, 0);
 
 		const newName = 'Nytt Testnamn';
 		await dialog.getByLabel('Nytt visningsnamn').fill(newName);
@@ -67,9 +65,7 @@ test.describe('auth flow', () => {
 		await expect(page.locator('h1')).toContainText('Hej,');
 
 		// Open the password edit dialog (third "Ändra" button)
-		await page.getByRole('button', { name: 'Ändra' }).nth(2).click();
-		const dialog = page.getByRole('dialog');
-		await expect(dialog).toBeVisible();
+		const dialog = await openEditDialog(page, 2);
 
 		// Change password
 		const newPassword = 'NewPassword456!';

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { EMAIL_TEMPLATES } from '../src/lib/server/email.templates';
 
@@ -78,10 +78,27 @@ export async function selectCalendarDate(page: Page, isoDate: string) {
 
 	// Click the day cell — bits-ui Day buttons have data-value="YYYY-MM-DD"
 	await calendar.locator(`[data-calendar-day][data-value="${isoDate}"]`).click();
+
+	// Gate on the slot list binding to the newly-selected date — without this,
+	// subsequent assertions race the calendar's state propagation under CI load.
+	await expect(page.locator(`[data-slots-date="${isoDate}"]`)).toBeVisible();
 }
 
 export async function confirmCancelDialog(page: Page) {
 	await page.getByRole('alertdialog').getByRole('button', { name: 'Bekräfta' }).click();
+}
+
+// Retries the click until the dialog opens. Inline `onclick` handlers on the account
+// page only wire up after Svelte hydration; a click that lands pre-hydration is silently
+// dropped, so a single click can race the page becoming interactive.
+export async function openEditDialog(page: Page, nth: number): Promise<Locator> {
+	const button = page.getByRole('button', { name: 'Ändra' }).nth(nth);
+	const dialog = page.getByRole('dialog');
+	await expect(async () => {
+		await button.click();
+		await expect(dialog).toBeVisible({ timeout: 250 });
+	}).toPass();
+	return dialog;
 }
 
 export async function login(page: Page, user: { username: string; password: string }) {

--- a/src/lib/components/Slots.svelte
+++ b/src/lib/components/Slots.svelte
@@ -81,7 +81,7 @@
 	}
 </script>
 
-<div class="grid grid-cols-5 gap-2">
+<div class="grid grid-cols-5 gap-2" data-slots-date={date.toString()}>
 	{#each slots as slot (slot.timeBlockId)}
 		{@const timeRange = `${formatHourNumShort(slot.start)}–${formatHourNumShort(slot.end)}`}
 		{#if slot.status === 'free'}


### PR DESCRIPTION
## Summary

- **#24**: `Slots.svelte` exposes `data-slots-date={date.toString()}` on the slot container; `selectCalendarDate` now gates on that attribute matching the requested date before returning. The "stale slot list during date change" symptom was a hydration race — clicking the calendar pre-hydration left `date` at today.
- **#25**: New `openEditDialog(page, nth)` helper retries the "Ändra" click via `expect(...).toPass()` until the dialog opens. Inline `onclick` handlers on the konto page only wire up after Svelte hydration, so a pre-hydration click is silently dropped. Applied to both the `change display name` and `change password` tests in `auth.e2e.ts`. (Email-change kept as-is per #25's out-of-scope note.)

No fixed-duration sleeps introduced.

Closes #24
Closes #25

## Test plan

- [x] `pnpm test` — full suite green (34 passed, 2 unrelated SSE skipped)
- [x] `pnpm test:e2e --grep "change password|login, view slots, book" --repeat-each 5` — 10/10 passes
- [x] CI green on consecutive runs