### PR TITLE
feat(admin): icons, clickable rows, and column sorting on apartment list

### DIFF
--- a/e2e/admin.e2e.ts
+++ b/e2e/admin.e2e.ts
@@ -103,7 +103,7 @@ test.describe('admin', () => {
 		await expect(page.getByRole('columnheader', { name: 'Senast aktiv' })).toBeVisible();
 
 		// The admin's own row should have a populated cell because login bumped the timestamp.
-		// Column order: Lägenhet, Namn, E-post, Senast aktiv, Status, action.
+		// Column order: Lägenhet, Namn, indicators, Senast aktiv.
 		const adminRow = page.getByRole('row').filter({ hasText: admin.username });
 		const lastActiveCell = adminRow.locator('td').nth(3);
 		await expect(lastActiveCell).toBeVisible();

--- a/src/lib/api/admin.remote.ts
+++ b/src/lib/api/admin.remote.ts
@@ -8,6 +8,8 @@ import { auth, requireAdmin } from '$lib/server/auth';
 import { apartmentSchema } from '$lib/server/auth.config';
 import { db } from '$lib/server/db';
 import { user as userTable } from '$lib/server/db/auth.schema';
+import { reminderPreference } from '$lib/server/db/reminder.schema';
+import { calendarToken } from '$lib/server/db/calendar.schema';
 import { getReminderPreferences, setReminderPreference } from '$lib/server/reminder';
 import { getExistingToken, createToken, regenerateToken, deleteToken } from '$lib/server/calendar';
 import { RESOURCES } from '$lib/types/bookings';
@@ -35,18 +37,32 @@ function buildCalendarUrl(token: string): string {
 
 export const listUsers = query(async () => {
 	requireAdmin();
-	return db
-		.select({
-			id: userTable.id,
-			username: userTable.username,
-			name: userTable.name,
-			email: userTable.email,
-			emailVerified: userTable.emailVerified,
-			role: userTable.role,
-			lastActiveAt: userTable.lastActiveAt
-		})
-		.from(userTable)
-		.orderBy(userTable.username);
+	const [users, reminderRows, calendarRows] = await Promise.all([
+		db
+			.select({
+				id: userTable.id,
+				username: userTable.username,
+				name: userTable.name,
+				role: userTable.role,
+				lastActiveAt: userTable.lastActiveAt
+			})
+			.from(userTable)
+			.orderBy(userTable.username),
+		db
+			.selectDistinct({ userId: reminderPreference.userId })
+			.from(reminderPreference)
+			.where(eq(reminderPreference.enabled, true)),
+		db.select({ userId: calendarToken.userId }).from(calendarToken)
+	]);
+
+	const withReminders = new Set(reminderRows.map((r) => r.userId));
+	const withCalendar = new Set(calendarRows.map((r) => r.userId));
+
+	return users.map((u) => ({
+		...u,
+		hasActiveReminderPreference: withReminders.has(u.id),
+		hasCalendarSubscription: withCalendar.has(u.id)
+	}));
 });
 
 export const getUserByUsername = query(

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import { goto } from '$app/navigation';
 	import { MetaTags } from 'svelte-meta-tags';
 	import { metaDefaults } from '$lib/meta';
 	import { listUsers } from '$lib/api/admin.remote';
 	import { formatDateTime } from '$lib/utils/date';
 
 	let users = $derived(await listUsers());
+
+	function rowHref(username: string | null) {
+		return resolve('/admin/[username]', { username: username ?? '' });
+	}
+
+	function handleRowClick(event: MouseEvent, username: string | null) {
+		if (event.defaultPrevented) return;
+		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+		if (event.button !== 0) return;
+		const target = event.target as HTMLElement | null;
+		if (target?.closest('a')) return;
+		goto(rowHref(username));
+	}
 </script>
 
 <MetaTags {...metaDefaults} title="Admin" robots="noindex,nofollow" />
@@ -15,45 +29,96 @@
 	Hantera kontouppgifter, aviseringar och kalenderprenumerationer.
 </p>
 
-<table class="w-full border-collapse text-sm">
-	<thead>
-		<tr
-			class="border-b border-border text-left text-xs tracking-wide text-text-secondary uppercase"
-		>
-			<th class="py-3 pr-4 font-normal">Lägenhet</th>
-			<th class="py-3 pr-4 font-normal">Namn</th>
-			<th class="py-3 pr-4 font-normal">E-post</th>
-			<th class="py-3 pr-4 font-normal">Senast aktiv</th>
-			<th class="py-3 pr-4 font-normal">Status</th>
-			<th class="py-3 pl-4 font-normal"></th>
-		</tr>
-	</thead>
-	<tbody>
-		{#each users as user (user.id)}
-			<tr class="border-b border-border-subtle">
-				<td class="py-3 pr-4 font-mono">{user.username}</td>
-				<td class="py-3 pr-4">{user.name}</td>
-				<td class="py-3 pr-4 text-text-secondary">{user.email}</td>
-				<td class="py-3 pr-4 text-text-secondary">
-					{user.lastActiveAt ? formatDateTime(user.lastActiveAt) : '—'}
-				</td>
-				<td class="py-3 pr-4 text-xs">
-					{#if user.role === 'admin'}
-						<span class="text-accent">Admin</span>
-					{/if}
-					{#if !user.emailVerified}
-						<span class="text-text-muted">Overifierad e-post</span>
-					{/if}
-				</td>
-				<td class="py-3 pl-4 text-right">
-					<a
-						href={resolve('/admin/[username]', { username: user.username ?? '' })}
-						class="text-sm text-link underline decoration-1 underline-offset-3 transition-colors duration-120 hover:text-link-hover"
-					>
-						Visa
-					</a>
-				</td>
+<div class="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+	<table class="w-full border-collapse text-sm">
+		<thead>
+			<tr
+				class="border-b border-border text-left text-xs tracking-wide text-text-secondary uppercase"
+			>
+				<th class="w-px py-3 pr-4 font-normal whitespace-nowrap">Lägenhet</th>
+				<th class="w-px py-3 pr-4 font-normal whitespace-nowrap">Namn</th>
+				<th class="w-px py-3 pr-10 font-normal whitespace-nowrap">Status</th>
+				<th class="py-3 font-normal">Senast aktiv</th>
 			</tr>
-		{/each}
-	</tbody>
-</table>
+		</thead>
+		<tbody>
+			{#each users as user (user.id)}
+				<tr
+					class="cursor-pointer border-b border-border-subtle transition-colors duration-120 focus-within:bg-bg-alt hover:bg-bg-alt"
+					onclick={(e) => handleRowClick(e, user.username)}
+				>
+					<td class="py-3 pr-4 font-mono whitespace-nowrap">
+						<a
+							href={rowHref(user.username)}
+							class="text-text-primary no-underline focus-visible:underline focus-visible:decoration-1 focus-visible:underline-offset-3"
+						>
+							{user.username}
+						</a>
+					</td>
+					<td class="py-3 pr-4 whitespace-nowrap">{user.name}</td>
+					<td class="py-3 pr-10 whitespace-nowrap text-text-secondary">
+						<span class="inline-flex items-center gap-2">
+							<svg
+								class={['size-4', user.role !== 'admin' && 'text-border']}
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-label={user.role === 'admin' ? 'Admin' : undefined}
+								aria-hidden={user.role === 'admin' ? undefined : 'true'}
+							>
+								{#if user.role === 'admin'}<title>Admin</title>{/if}
+								<path
+									d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+								/>
+							</svg>
+							<svg
+								class={['size-4', !user.hasActiveReminderPreference && 'text-border']}
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-label={user.hasActiveReminderPreference ? 'Aviseringar' : undefined}
+								aria-hidden={user.hasActiveReminderPreference ? undefined : 'true'}
+							>
+								{#if user.hasActiveReminderPreference}<title>Aviseringar</title>{/if}
+								<path d="M10.268 21a2 2 0 0 0 3.464 0" />
+								<path
+									d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
+								/>
+							</svg>
+							<svg
+								class={['size-4', !user.hasCalendarSubscription && 'text-border']}
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-label={user.hasCalendarSubscription ? 'Kalenderprenumeration' : undefined}
+								aria-hidden={user.hasCalendarSubscription ? undefined : 'true'}
+							>
+								{#if user.hasCalendarSubscription}<title>Kalenderprenumeration</title>{/if}
+								<path d="M11 14h1v4" />
+								<path d="M16 2v4" />
+								<path d="M3 10h18" />
+								<path d="M8 2v4" />
+								<rect x="3" y="4" width="18" height="18" rx="2" />
+							</svg>
+						</span>
+					</td>
+					<td class="py-3 whitespace-nowrap text-text-secondary">
+						{user.lastActiveAt ? formatDateTime(user.lastActiveAt) : '—'}
+					</td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -6,7 +6,48 @@
 	import { listUsers } from '$lib/api/admin.remote';
 	import { formatDateTime } from '$lib/utils/date';
 
+	type SortKey = 'username' | 'name' | 'lastActiveAt';
+	type SortDir = 'asc' | 'desc';
+
+	const defaultDir: Record<SortKey, SortDir> = {
+		username: 'asc',
+		name: 'asc',
+		lastActiveAt: 'desc'
+	};
+
 	let users = $derived(await listUsers());
+	let sort = $state<{ key: SortKey; dir: SortDir }>({ key: 'username', dir: 'asc' });
+
+	let sortedUsers = $derived.by(() => {
+		const factor = sort.dir === 'asc' ? 1 : -1;
+		return [...users].sort((a, b) => {
+			if (sort.key === 'lastActiveAt') {
+				if (a.lastActiveAt && b.lastActiveAt) {
+					return factor * (a.lastActiveAt.getTime() - b.lastActiveAt.getTime());
+				}
+				if (a.lastActiveAt) return -1;
+				if (b.lastActiveAt) return 1;
+				return 0;
+			}
+			const av = a[sort.key] ?? '';
+			const bv = b[sort.key] ?? '';
+			return factor * av.localeCompare(bv, 'sv');
+		});
+	});
+
+	function toggleSort(key: SortKey) {
+		if (sort.key === key) {
+			sort.dir = sort.dir === 'asc' ? 'desc' : 'asc';
+		} else {
+			sort.key = key;
+			sort.dir = defaultDir[key];
+		}
+	}
+
+	function ariaSort(key: SortKey): 'ascending' | 'descending' | 'none' {
+		if (sort.key !== key) return 'none';
+		return sort.dir === 'asc' ? 'ascending' : 'descending';
+	}
 
 	function rowHref(username: string | null) {
 		return resolve('/admin/[username]', { username: username ?? '' });
@@ -35,14 +76,20 @@
 			<tr
 				class="border-b border-border text-left text-xs tracking-wide text-text-secondary uppercase"
 			>
-				<th class="w-px py-3 pr-4 font-normal whitespace-nowrap">Lägenhet</th>
-				<th class="w-px py-3 pr-4 font-normal whitespace-nowrap">Namn</th>
+				<th class="w-px py-3 pr-4 font-normal whitespace-nowrap" aria-sort={ariaSort('username')}>
+					{@render sortHeader('username', 'Lägenhet')}
+				</th>
+				<th class="w-px py-3 pr-4 font-normal whitespace-nowrap" aria-sort={ariaSort('name')}>
+					{@render sortHeader('name', 'Namn')}
+				</th>
 				<th class="w-px py-3 pr-10 font-normal whitespace-nowrap">Status</th>
-				<th class="py-3 font-normal">Senast aktiv</th>
+				<th class="py-3 font-normal" aria-sort={ariaSort('lastActiveAt')}>
+					{@render sortHeader('lastActiveAt', 'Senast aktiv')}
+				</th>
 			</tr>
 		</thead>
 		<tbody>
-			{#each users as user (user.id)}
+			{#each sortedUsers as user (user.id)}
 				<tr
 					class="cursor-pointer border-b border-border-subtle transition-colors duration-120 focus-within:bg-bg-alt hover:bg-bg-alt"
 					onclick={(e) => handleRowClick(e, user.username)}
@@ -122,3 +169,30 @@
 		</tbody>
 	</table>
 </div>
+
+{#snippet sortHeader(key: SortKey, label: string)}
+	<button
+		type="button"
+		class="inline-flex cursor-pointer items-center gap-1 transition-colors duration-120 hover:text-text-primary"
+		onclick={() => toggleSort(key)}
+	>
+		{label}
+		<svg
+			class={['size-3', sort.key !== key && 'invisible']}
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			{#if sort.dir === 'asc'}
+				<polyline points="6 15 12 9 18 15" />
+			{:else}
+				<polyline points="6 9 12 15 18 9" />
+			{/if}
+		</svg>
+	</button>
+{/snippet}


### PR DESCRIPTION
## Summary

Two-commit reshape of the admin apartment list:

- **Icons + clickable rows** (commit 1): drops the *Status* and *Visa* columns. A new *Status* column shows three indicator icons per apartment — admin (shield), reminders enabled (bell), calendar subscription (calendar) — ghosted to `text-border` when off, full strength when on. The whole row is clickable via `goto`; the apartment number is a real `<a>` so middle-click, Cmd-click, and keyboard nav stay native. Email column dropped from the list (still on the detail page). The first three columns shrink to content; *Senast aktiv* absorbs remaining width. Wrapper provides horizontal scroll on narrow viewports.
- **Column sorting** (commit 2): *Lägenhet*, *Namn*, and *Senast aktiv* are sortable. Default sort is `username asc` (matches previous behaviour). Date column defaults to `desc` on first click so most-recent-first appears as expected; null `lastActiveAt` always sinks to the bottom. `aria-sort` is set on the active `<th>` for screen readers. Inactive chevrons reserve their space (`invisible`) so column widths don't jiggle.

`listUsers` now also returns `hasActiveReminderPreference` and `hasCalendarSubscription` via two small parallel queries; `emailVerified` is dropped from the list query since `requireEmailVerification: true` makes it dead.

## Test plan

- [x] `pnpm test` (34 e2e + unit) — pass
- [x] `pnpm check` clean
- [x] Manual visual check: hover row highlight, click a row → detail page, middle-click apartment number → opens in new tab, click each sortable header → toggles direction, ghost icons render at `text-border`
- [x] Manual: confirm narrow-viewport horizontal scroll behaves