### PR TITLE
fix(ui): cream rubber-band at bottom on mobile

### DIFF
--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -50,7 +50,7 @@
 	html {
 		font-family: var(--font-body);
 		color: var(--color-text-primary);
-		background-color: var(--color-accent);
+		background: linear-gradient(to bottom, var(--color-accent) 50%, var(--color-bg) 50%) fixed;
 		line-height: 1.6;
 	}
 


### PR DESCRIPTION
## Summary

- Replace the solid green `html` background with a fixed-attachment linear-gradient — green top half, cream bottom half. The seam at 50% is never visible because the body always covers it; only the iOS rubber-band overscroll exposes the `html` background.
- Net effect: top overscroll keeps the nice navbar-green pull-down, bottom overscroll now shows the page cream, and the iOS 26 liquid-glass URL bar (when at the bottom of the viewport) samples cream instead of picking up the navbar green.
- `<meta name="theme-color">` stays green so the top status bar (PWA / Android Chrome) still matches the navbar.

## Test plan

- [ ] iOS Safari: scroll to top, pull down → still shows navbar green.
- [ ] iOS Safari: scroll to bottom of a long page, pull up → shows cream.
- [ ] iOS Safari, short page (e.g. /kontakt): pull up at bottom → shows cream.
- [ ] iOS 26 with liquid-glass URL bar at the bottom: URL bar tints cream against page content, no green bleed.
- [ ] Android Chrome: address bar still tinted green from `theme-color` meta tag.
- [ ] Desktop: no visible change (no rubber-band).