### PR TITLE
revert: cream rubber-band at bottom on mobile (#31)

### DIFF
--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -50,7 +50,7 @@
 	html {
 		font-family: var(--font-body);
 		color: var(--color-text-primary);
-		background: linear-gradient(to bottom, var(--color-accent) 50%, var(--color-bg) 50%) fixed;
+		background-color: var(--color-accent);
 		line-height: 1.6;
 	}
 


### PR DESCRIPTION
## Summary

- Reverts #31. The `background-attachment: fixed` gradient approach didn't work as intended on iOS Safari: the gradient image renders inside the document box, but the rubber-band area is painted using only `background-color`, so the bottom rubber-band ended up either white (with the shorthand) or solid green (with the longhand fallback) — neither was the desired cream.
- Restores the original solid green `background-color: var(--color-accent)` so the top "navbar pull-down" rubber-band still looks correct.
- We can revisit the bottom mismatch separately (likely by changing the canvas color, accepting a different trade-off, or going JS-driven).

## Test plan

- [x] iOS Safari: top rubber-band still shows navbar green (the effect we wanted to keep).
- [x] Bottom rubber-band returns to green (status quo ante — known cosmetic mismatch we'll address in a follow-up).