### PR TITLE
content(news): announce spring events — trädgårdsfix, vårstädning, årsmöte

### DIFF
--- a/content/news/arsmote-26.md
+++ b/content/news/arsmote-26.md
@@ -1,6 +1,6 @@
 ---
 title: Årsmöte den 15 juni
-date: '2026-04-29'
+date: '2026-05-01'
 summary: Måndagen den 15 juni kl. 18:00 håller vi årsmöte i BRF Skiftesgatan 4 på innergården. Vi går igenom årsredovisningen och väljer ny styrelse.
 ---
 

--- a/content/news/arsmote-26.md
+++ b/content/news/arsmote-26.md
@@ -1,13 +1,15 @@
 ---
-title: Årsmöte 2026
-date: '2026-04-12'
-summary: Preliminärt datum för årsmöte i BRF Skiftesgatan 4 är satt till den 10 juni 2026. Mer information kommer närmare mötet.
+title: Årsmöte den 15 juni
+date: '2026-04-29'
+summary: Måndagen den 15 juni kl. 18:00 håller vi årsmöte i BRF Skiftesgatan 4 på innergården. Vi går igenom årsredovisningen och väljer ny styrelse.
 ---
 
-## Preliminärt datum för årsmöte i BRF Skiftesgatan 4
+## Save the date — årsmöte 15 juni
 
-Preliminärt datum för årsmöte i BRF Skiftesgatan 4 är satt till den 10 juni 2026.
+Måndagen den 15 juni kl. 18:00 är du välkommen på årsmöte för BRF Skiftesgatan 4. Om vädret tillåter håller vi mötet utomhus på vår fina innergård. Vid dåligt väder ses vi i pannrummet nere i källaren vid C-uppgången.
 
-Mer information kommer närmare mötet. Vi uppmuntrar alla medlemmar att delta och vara delaktiga i föreningens beslut och framtid.
+På mötet går vi bland annat igenom årsredovisningen för 2025 och väljer ny styrelse för det kommande året.
 
-Håll utkik efter mer detaljerad information om tid och plats!
+Formell kallelse med dagordning, fullmakt och övriga bilagor skickas ut närmare mötet. Årsredovisningen kommer också att finnas tillgänglig i god tid innan — håll utkik här på hemsidan och i Facebook-gruppen "BRF Skiftesgatan".
+
+Vi hoppas att så många som möjligt har möjlighet att delta!

--- a/content/news/tradgardsfix-26.md
+++ b/content/news/tradgardsfix-26.md
@@ -1,0 +1,13 @@
+---
+title: Trädgårdsfix på innergården 6 maj
+date: '2026-05-01'
+summary: Onsdagen den 6 maj kl. 18:00 ses vi på innergården för en kväll i trädgårdens tecken, med fokus på våra pallkragar. Du som vill plantera är varmt välkommen att hjälpa till!
+---
+
+## Dags att fixa till pallkragarna
+
+Onsdagen den 6 maj kl. 18:00 samlas vi på innergården för att fräscha upp våra pallkragar inför säsongen. Föreningen står för ny planteringsjord — det vi behöver är några extra händer.
+
+Du som tänker plantera något i sommar är välkommen att vara med och hjälpa till med arbetet. Vad som ska planteras, och hur vi fördelar utrymmet, kommer vi överens om på plats tillsammans med dem som dyker upp.
+
+Ta gärna med egna handskar om du har, men vi löser det mesta på plats. Välkomna!

--- a/content/news/tradgardsfix-26.md
+++ b/content/news/tradgardsfix-26.md
@@ -1,6 +1,6 @@
 ---
 title: Trädgårdsfix på innergården 6 maj
-date: '2026-05-01'
+date: '2026-04-29'
 summary: Onsdagen den 6 maj kl. 18:00 ses vi på innergården för en kväll i trädgårdens tecken, med fokus på våra pallkragar. Du som vill plantera är varmt välkommen att hjälpa till!
 ---
 

--- a/content/news/varstadning-26.md
+++ b/content/news/varstadning-26.md
@@ -1,15 +1,18 @@
 ---
-title: Vårstädning 2026 är senarelagd
-date: '2026-04-20'
-summary: Årets vårstädning skjuts upp något jämfört med tidigare år för att den nysådda gräsmattan ska hinna etablera sig. Datum meddelas senare.
+title: Vårstädning den 18 maj
+date: '2026-04-30'
+summary: Måndagen den 18 maj kl. 18:00 samlas vi på innergården för vårstädning. Vi bär upp utemöblerna från källaren och putsar dörrar och fönster. Fika utlovas!
 ---
 
-## Vårstädningen skjuts upp i år
+## Vårstädning på innergården
 
-Årets vårstädning kommer att hållas senare än vanligt. Anledningen är att vi nyligen har sått nytt gräs på föreningens gemensamma ytor, och vi vill ge det nya gräset tid att slå rot och etablera sig innan vi samlas för att trampa, kratta och städa runt omkring.
+Måndagen den 18 maj kl. 18:00 är det dags för årets vårstädning. Vi ses på innergården och hjälps åt med några viktiga sysslor inför sommaren:
 
-Att gå på en nysådd gräsmatta för tidigt riskerar att skada de späda grässtråna och ge oss en ojämn och glesare gräsmatta under resten av säsongen. Genom att vänta några extra veckor ger vi gräset bästa möjliga start.
+- Bära upp utemöblerna från källaren och ställa i ordning på innergården
+- Putsa och torka av entrédörrar i de gemensamma utrymmena
 
-Nytt datum för vårstädningen meddelas så snart gräset har kommit igång ordentligt. Håll utkik efter mer information i Facebook-gruppen och här på hemsidan.
+Föreningen står för redskap och städmaterial — det räcker att du själv kommer. Som tack för hjälpen bjuder vi förstås på fika.
 
-Tack för ert tålamod!
+Passa också på att slå en pratstund med oss i styrelsen. Vi finns på plats hela kvällen och svarar gärna på frågor om föreningen — eller berättar om hur det är att själv sitta i styrelsen, för dig som funderar på att engagera dig.
+
+Välkomna!

--- a/e2e/content.e2e.ts
+++ b/e2e/content.e2e.ts
@@ -21,10 +21,10 @@ test.describe('content pages', () => {
 
 		// Open Nyheter dropdown and click the other article
 		await page.locator('nav').getByRole('button', { name: 'Nyheter' }).click();
-		await page.locator('nav').getByRole('link', { name: 'Årsmöte 2026' }).click();
+		await page.locator('nav').getByRole('link', { name: 'Årsmöte den 15 juni' }).click();
 
 		await expect(page).toHaveURL('/nyheter/arsmote-26');
-		await expect(page.locator('h1')).toHaveText('Årsmöte 2026');
+		await expect(page.locator('h1')).toHaveText('Årsmöte den 15 juni');
 	});
 
 	test('information listing and detail pages', async ({ page }) => {


### PR DESCRIPTION
## Summary
- New post **trädgårdsfix-26**: pallkrage-fokuserad trädgårdskväll on Wed 6 May 18:00; föreningen står för jord, deltagarna hjälper till med arbetet.
- Replaces **varstadning-26** (was: "senarelagd, datum meddelas senare") with confirmed Mon 18 May 18:00 på innergården, fika utlovas, styrelsen är på plats.
- Replaces **arsmote-26** (was: "preliminärt 10 juni") with confirmed save-the-date Mon 15 juni 18:00 på innergården, pannrummet vid C-uppgången som regnreserv. Formell kallelse + årsredovisning skickas senare.
- Pub-dates spread one day apart (29/30 apr, 1 may) so the news feed sorts the most-imminent event on top.
- Updates `e2e/content.e2e.ts` to match the new årsmöte title.

## Test plan
- [x] `pnpm test` — all 34 e2e tests pass (2 SSE tests skipped as before)
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] Visual check on `/nyheter` to confirm sort order and rendering