### PR TITLE
feat(booking): time block cache + bookSlot returns hours (#36)

### DIFF
--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -7,7 +7,6 @@ import { log } from '$lib/server/log';
 import { slotPhrase, slotTimeRange } from '$lib/server/log.prose';
 import {
 	getBookingCalendar,
-	getTimeBlockStartHour,
 	bookSlot,
 	buildBookingPayload,
 	cancelBooking as cancelBookingDb,
@@ -53,8 +52,6 @@ export const book = command(
 		const dateError = validateBookingDate(date);
 		if (dateError) error(400, VALIDATE_DATE_MESSAGES[dateError]);
 
-		const startHour = await getTimeBlockStartHour(timeBlockId);
-
 		const result = await bookSlot({
 			userId: user.id,
 			timeBlockId,
@@ -68,19 +65,19 @@ export const book = command(
 		if (result.kind === 'already_booked') error(409, 'Du har redan en kommande bokning');
 		if (result.kind === 'slot_taken') {
 			log.warn(
-				`[booking] apartment ${user.username} tried to book ${slotPhrase(resource, date.toString(), startHour!)} but the slot was already taken`
+				`[booking] apartment ${user.username} tried to book ${slotPhrase(resource, date.toString(), result.startHour, result.endHour)} but the slot was already taken`
 			);
 			error(409, 'Tiden är redan bokad');
 		}
 
-		const newSlot = slotPhrase(resource, date.toString(), startHour!);
+		const newSlot = slotPhrase(resource, date.toString(), result.startHour, result.endHour);
 		if (result.cancelled) {
 			const fromRange = slotTimeRange(
-				result.cancelled.resource,
 				result.cancelled.date,
-				result.cancelled.startHour
+				result.cancelled.startHour,
+				result.cancelled.endHour
 			);
-			const toRange = slotTimeRange(resource, date.toString(), startHour!);
+			const toRange = slotTimeRange(date.toString(), result.startHour, result.endHour);
 			log.info(
 				`[booking] apartment ${user.username} moved their ${resource} booking from ${fromRange} to ${toRange}`
 			);
@@ -120,7 +117,7 @@ export const cancelBooking = command(v.object({ bookingId: v.number() }), async 
 		error(404, 'Bokningen hittades inte');
 	}
 	log.info(
-		`[booking] apartment ${user.username} cancelled their booking of ${slotPhrase(result.resource, result.date, result.startHour)}`
+		`[booking] apartment ${user.username} cancelled their booking of ${slotPhrase(result.resource, result.date, result.startHour, result.endHour)}`
 	);
 
 	await requested(getBookingData, 5).refreshAll();

--- a/src/lib/server/booking.spec.ts
+++ b/src/lib/server/booking.spec.ts
@@ -12,6 +12,7 @@ import {
 	buildBookingPayload,
 	isBookingActive,
 	validateBookingDate,
+	__buildTimeBlockMap,
 	type BookingCalendarRow
 } from './booking';
 
@@ -67,6 +68,77 @@ describe('TIME_BLOCKS drift', () => {
 					expect.objectContaining({ resource: 'laundry_room', startHour: 8, endHour: 11 })
 				])
 			);
+		} finally {
+			await client.close();
+		}
+	});
+});
+
+describe('time block cache', () => {
+	it('builds a map from time_block id to (resource, startHour, endHour) covering the current schedule', async () => {
+		const client = new PGlite();
+		const db = drizzle(client, { schema });
+		try {
+			const pushed = await pushSchema(schema, db as unknown as Parameters<typeof pushSchema>[1]);
+			await pushed.apply();
+
+			await seedTimeBlocks(db);
+
+			const map = await __buildTimeBlockMap(db);
+
+			const rows = await db.select().from(timeBlock);
+			for (const row of rows) {
+				expect(map.get(row.id)).toEqual({
+					resource: row.resource,
+					startHour: row.startHour,
+					endHour: row.endHour
+				});
+			}
+			for (const [resource, blocks] of Object.entries(TIME_BLOCKS)) {
+				for (const block of blocks) {
+					const row = rows.find(
+						(r) =>
+							r.resource === resource &&
+							r.startHour === block.startHour &&
+							r.endHour === block.endHour
+					);
+					expect(
+						row,
+						`seeded row for ${resource} ${block.startHour}-${block.endHour}`
+					).toBeDefined();
+					expect(map.get(row!.id)).toEqual({
+						resource,
+						startHour: block.startHour,
+						endHour: block.endHour
+					});
+				}
+			}
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('resolves a historic time_block row whose (resource, startHour) is not in the current TIME_BLOCKS', async () => {
+		const client = new PGlite();
+		const db = drizzle(client, { schema });
+		try {
+			const pushed = await pushSchema(schema, db as unknown as Parameters<typeof pushSchema>[1]);
+			await pushed.apply();
+
+			const [historic] = await db
+				.insert(timeBlock)
+				.values({ resource: 'laundry_room', startHour: 8, endHour: 11 })
+				.returning();
+
+			await seedTimeBlocks(db);
+
+			const map = await __buildTimeBlockMap(db);
+
+			expect(map.get(historic.id)).toEqual({
+				resource: 'laundry_room',
+				startHour: 8,
+				endHour: 11
+			});
 		} finally {
 			await client.close();
 		}

--- a/src/lib/server/booking.ts
+++ b/src/lib/server/booking.ts
@@ -43,13 +43,46 @@ function isUniqueViolation(e: unknown): boolean {
 	return e instanceof Error && 'code' in e && e.code === PG_UNIQUE_VIOLATION;
 }
 
-export async function getTimeBlockStartHour(timeBlockId: number): Promise<number | null> {
-	const [row] = await db
-		.select({ startHour: timeBlock.startHour })
-		.from(timeBlock)
-		.where(eq(timeBlock.id, timeBlockId))
-		.limit(1);
-	return row?.startHour ?? null;
+type TimeBlockHours = { resource: Resource; startHour: number; endHour: number };
+
+// Module-private lazy cache. Concurrent callers race the synchronous `??=`
+// assignment and end up sharing the same in-flight Promise — see ADR-0004 for
+// why historic time_block rows must resolve through this cache.
+let timeBlockCachePromise: Promise<Map<number, TimeBlockHours>> | undefined;
+
+export async function __buildTimeBlockMap(
+	database: typeof db
+): Promise<Map<number, TimeBlockHours>> {
+	const rows = await database
+		.select({
+			id: timeBlock.id,
+			resource: timeBlock.resource,
+			startHour: timeBlock.startHour,
+			endHour: timeBlock.endHour
+		})
+		.from(timeBlock);
+	return new Map(
+		rows.map((r) => [r.id, { resource: r.resource, startHour: r.startHour, endHour: r.endHour }])
+	);
+}
+
+/**
+ * Resolves a `time_block_id` to its `(resource, startHour, endHour)` via a
+ * lazy module-level cache. Used internally by `bookSlot`; exported for the
+ * follow-up slice of #34 that drops `innerJoin(timeBlock, ...)` from
+ * `reminder.ts` / `reminder.scheduler.ts` / `calendar.ts` and resolves a
+ * Booking's hours through this cache instead. Per ADR-0004 the cache covers
+ * historic rows (whose `(resource, startHour)` may no longer be in
+ * `TIME_BLOCKS`), which a `findTimeBlock` constant lookup cannot.
+ *
+ * @lintignore
+ */
+export async function getTimeBlockHours(timeBlockId: number): Promise<TimeBlockHours> {
+	timeBlockCachePromise ??= __buildTimeBlockMap(db);
+	const map = await timeBlockCachePromise;
+	const hours = map.get(timeBlockId);
+	if (!hours) throw new Error(`unknown time block id ${timeBlockId}`);
+	return hours;
 }
 
 function maxBookingDate(from: CalendarDate = today(TIMEZONE)): CalendarDate {
@@ -192,15 +225,24 @@ export function buildBookingPayload(
 	return { bookingCalendar, activeBooking };
 }
 
+type CancelledSlot = {
+	resource: Resource;
+	date: string;
+	startHour: number;
+	endHour: number;
+};
+
 type BookSlotResult =
 	| {
 			kind: 'ok';
 			booking: typeof booking.$inferSelect;
-			cancelled: { resource: Resource; date: string; startHour: number } | null;
+			startHour: number;
+			endHour: number;
+			cancelled: CancelledSlot | null;
 	  }
-	| { kind: 'replace_not_found' }
-	| { kind: 'already_booked' }
-	| { kind: 'slot_taken' };
+	| { kind: 'replace_not_found'; startHour: number; endHour: number }
+	| { kind: 'already_booked'; startHour: number; endHour: number }
+	| { kind: 'slot_taken'; startHour: number; endHour: number };
 
 class BookSlotConflict extends Error {
 	constructor(public kind: 'replace_not_found' | 'already_booked' | 'slot_taken') {
@@ -216,6 +258,7 @@ export async function bookSlot(params: {
 	replaceBookingId?: number;
 	now: ZonedDateTime;
 }): Promise<BookSlotResult> {
+	const target = await getTimeBlockHours(params.timeBlockId);
 	try {
 		return await db.transaction(async (tx) => {
 			// Serialize concurrent booking attempts by the same user. Without this lock,
@@ -224,14 +267,15 @@ export async function bookSlot(params: {
 			await tx.select({ id: user.id }).from(user).where(eq(user.id, params.userId)).for('update');
 
 			const activeWhere = activeBookingWhere(params.now);
-			let cancelled: { resource: Resource; date: string; startHour: number } | null = null;
+			let cancelled: CancelledSlot | null = null;
 
 			if (params.replaceBookingId !== undefined) {
 				const [info] = await tx
 					.select({
 						resource: booking.resource,
 						date: booking.date,
-						startHour: timeBlock.startHour
+						startHour: timeBlock.startHour,
+						endHour: timeBlock.endHour
 					})
 					.from(booking)
 					.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
@@ -281,14 +325,22 @@ export async function bookSlot(params: {
 					})
 					.returning();
 
-				return { kind: 'ok', booking: created, cancelled };
+				return {
+					kind: 'ok',
+					booking: created,
+					startHour: target.startHour,
+					endHour: target.endHour,
+					cancelled
+				};
 			} catch (e) {
 				if (isUniqueViolation(e)) throw new BookSlotConflict('slot_taken');
 				throw e;
 			}
 		});
 	} catch (e) {
-		if (e instanceof BookSlotConflict) return { kind: e.kind };
+		if (e instanceof BookSlotConflict) {
+			return { kind: e.kind, startHour: target.startHour, endHour: target.endHour };
+		}
 		throw e;
 	}
 }
@@ -297,13 +349,14 @@ export async function cancelBooking(
 	bookingId: number,
 	userId: string,
 	now: ZonedDateTime
-): Promise<{ resource: Resource; date: string; startHour: number } | null> {
+): Promise<CancelledSlot | null> {
 	const activeWhere = activeBookingWhere(now);
 	const [info] = await db
 		.select({
 			resource: booking.resource,
 			date: booking.date,
-			startHour: timeBlock.startHour
+			startHour: timeBlock.startHour,
+			endHour: timeBlock.endHour
 		})
 		.from(booking)
 		.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))

--- a/src/lib/server/log.prose.spec.ts
+++ b/src/lib/server/log.prose.spec.ts
@@ -4,32 +4,20 @@ import { slotPhrase, slotTimeRange } from './log.prose';
 describe('slotTimeRange', () => {
 	const date = '2026-05-04';
 
-	it('renders Laundry Room 07-10', () => {
-		expect(slotTimeRange('laundry_room', date, 7)).toBe('2026-05-04 07:00-10:00');
+	it('renders the time range from explicit start and end hours', () => {
+		expect(slotTimeRange(date, 7, 10)).toBe('2026-05-04 07:00-10:00');
 	});
 
-	it('renders Laundry Room 10-13', () => {
-		expect(slotTimeRange('laundry_room', date, 10)).toBe('2026-05-04 10:00-13:00');
+	it('renders multi-digit hours with zero-padding for the morning blocks', () => {
+		expect(slotTimeRange(date, 19, 22)).toBe('2026-05-04 19:00-22:00');
 	});
 
-	it('renders Laundry Room 13-16', () => {
-		expect(slotTimeRange('laundry_room', date, 13)).toBe('2026-05-04 13:00-16:00');
+	it('renders the all-day Outdoor Area block', () => {
+		expect(slotTimeRange(date, 7, 22)).toBe('2026-05-04 07:00-22:00');
 	});
 
-	it('renders Laundry Room 16-19', () => {
-		expect(slotTimeRange('laundry_room', date, 16)).toBe('2026-05-04 16:00-19:00');
-	});
-
-	it('renders Laundry Room 19-22', () => {
-		expect(slotTimeRange('laundry_room', date, 19)).toBe('2026-05-04 19:00-22:00');
-	});
-
-	it('renders Outdoor Area 07-22', () => {
-		expect(slotTimeRange('outdoor_area', date, 7)).toBe('2026-05-04 07:00-22:00');
-	});
-
-	it('throws on unknown start hour', () => {
-		expect(() => slotTimeRange('laundry_room', date, 8)).toThrow();
+	it('renders an arbitrary historic block whose hours are absent from the current TIME_BLOCKS', () => {
+		expect(slotTimeRange(date, 8, 11)).toBe('2026-05-04 08:00-11:00');
 	});
 });
 
@@ -37,10 +25,12 @@ describe('slotPhrase', () => {
 	const date = '2026-05-04';
 
 	it('prepends "the <resource>" to the time range', () => {
-		expect(slotPhrase('laundry_room', date, 10)).toBe('the laundry_room 2026-05-04 10:00-13:00');
+		expect(slotPhrase('laundry_room', date, 10, 13)).toBe(
+			'the laundry_room 2026-05-04 10:00-13:00'
+		);
 	});
 
 	it('renders Outdoor Area with full prefix', () => {
-		expect(slotPhrase('outdoor_area', date, 7)).toBe('the outdoor_area 2026-05-04 07:00-22:00');
+		expect(slotPhrase('outdoor_area', date, 7, 22)).toBe('the outdoor_area 2026-05-04 07:00-22:00');
 	});
 });

--- a/src/lib/server/log.prose.ts
+++ b/src/lib/server/log.prose.ts
@@ -1,21 +1,27 @@
-import { findTimeBlock, type Resource } from '$lib/types/bookings';
+import type { Resource } from '$lib/types/bookings';
 
 function pad2(n: number): string {
 	return n.toString().padStart(2, '0');
 }
 
-// Renders the date + time range of a Slot — "2026-05-04 10:00-13:00". The
-// end-hour is resolved from the Facility's Time Block table rather than
-// passed in, so call sites carry the (resource, date, startHour) trio they
-// already have.
-export function slotTimeRange(resource: Resource, date: string, startHour: number): string {
-	const { startHour: start, endHour: end } = findTimeBlock(resource, startHour);
-	return `${date} ${pad2(start)}:00-${pad2(end)}:00`;
+// Renders the date + time range of a Slot — "2026-05-04 10:00-13:00". Hours
+// are passed in rather than looked up: callers already hold them (from the
+// booking command's result, the cancel result, or a join). Per ADR-0004, hours
+// for an existing Booking must come from the cache (`getTimeBlockHours`) or a
+// join, never from `findTimeBlock` (constant lookup) — historic Bookings
+// reference Time Block rows that the current `TIME_BLOCKS` no longer covers.
+export function slotTimeRange(date: string, startHour: number, endHour: number): string {
+	return `${date} ${pad2(startHour)}:00-${pad2(endHour)}:00`;
 }
 
 // Renders a Slot in the canonical prose form used in server logs:
 // "the laundry_room 2026-05-04 10:00-13:00". Snake_case enum values stay
 // literal — see ADR-0003.
-export function slotPhrase(resource: Resource, date: string, startHour: number): string {
-	return `the ${resource} ${slotTimeRange(resource, date, startHour)}`;
+export function slotPhrase(
+	resource: Resource,
+	date: string,
+	startHour: number,
+	endHour: number
+): string {
+	return `the ${resource} ${slotTimeRange(date, startHour, endHour)}`;
 }

--- a/src/lib/server/reminder.scheduler.ts
+++ b/src/lib/server/reminder.scheduler.ts
@@ -51,7 +51,7 @@ export async function processReminders(): Promise<number> {
 				.set({ status: 'sent', sentAt: currentTime, resendId })
 				.where(eq(bookingReminder.id, reminder.id));
 			log.info(
-				`[scheduler] sent reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour)}`
+				`[scheduler] sent reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour, reminder.endHour)}`
 			);
 		} catch (e) {
 			const failReason = e instanceof Error ? e.message : String(e);
@@ -60,7 +60,7 @@ export async function processReminders(): Promise<number> {
 				.set({ status: 'failed', failReason })
 				.where(eq(bookingReminder.id, reminder.id));
 			log.error(
-				`[scheduler] failed to send reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour)}: ${failReason}`
+				`[scheduler] failed to send reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour, reminder.endHour)}: ${failReason}`
 			);
 		}
 	}


### PR DESCRIPTION
Closes #36 — child slice of #34.

## Summary

- **Cache.** New lazy `Promise<Map<id, {resource, startHour, endHour}>>` in `booking.ts`, loaded once via `SELECT * FROM time_block` (every row, per ADR-0004). Exported `getTimeBlockHours(id)`; concurrent callers share one in-flight Promise via `??=`. `getTimeBlockStartHour` removed.
- **`bookSlot` reshape.** All result kinds carry `startHour`/`endHour` for the target slot, looked up once from the cache before the transaction. `cancelled` payload and `cancelBooking` gain `endHour`.
- **`book` remote.** Builds log prose entirely from `bookSlot`'s result — no separate `SELECT` against `time_block` to format a log line.
- **Prose helpers.** `slotPhrase`/`slotTimeRange` now take both hours; `findTimeBlock` no longer runs in any production path that resolves a Booking's hours (per acceptance criterion).

## Out of scope

`innerJoin(timeBlock, …)` in `reminder.ts` / `reminder.scheduler.ts` / `calendar.ts` is unchanged — that migration belongs to the next slice of #34. `getTimeBlockHours` is exported now so the follow-up can drop those joins without touching this module again. (`@lintignore` JSDoc explains the deferred external caller to knip.)

## Test plan

- [x] PGlite test: `__buildTimeBlockMap(db)` covers every seeded current-schedule row
- [x] PGlite test: a synthetic historic row whose `(resource, startHour)` is absent from `TIME_BLOCKS` resolves correctly
- [x] `slotPhrase`/`slotTimeRange` specs rewritten for the new signature, including a historic-hours case
- [x] `pnpm test` (46 unit + 34 E2E), `pnpm lint`, `pnpm check`, `pnpm knip` all pass