### PR TITLE
feat(reminder): drop time_block joins, resolve hours via cache (#37)

### DIFF
--- a/src/lib/server/booking.ts
+++ b/src/lib/server/booking.ts
@@ -68,14 +68,9 @@ export async function __buildTimeBlockMap(
 
 /**
  * Resolves a `time_block_id` to its `(resource, startHour, endHour)` via a
- * lazy module-level cache. Used internally by `bookSlot`; exported for the
- * follow-up slice of #34 that drops `innerJoin(timeBlock, ...)` from
- * `reminder.ts` / `reminder.scheduler.ts` / `calendar.ts` and resolves a
- * Booking's hours through this cache instead. Per ADR-0004 the cache covers
- * historic rows (whose `(resource, startHour)` may no longer be in
- * `TIME_BLOCKS`), which a `findTimeBlock` constant lookup cannot.
- *
- * @lintignore
+ * lazy module-level cache. Per ADR-0004 the cache covers historic rows
+ * (whose `(resource, startHour)` may no longer be in `TIME_BLOCKS`), which a
+ * `findTimeBlock` constant lookup cannot.
  */
 export async function getTimeBlockHours(timeBlockId: number): Promise<TimeBlockHours> {
 	timeBlockCachePromise ??= __buildTimeBlockMap(db);

--- a/src/lib/server/reminder.scheduler.ts
+++ b/src/lib/server/reminder.scheduler.ts
@@ -7,8 +7,9 @@ import { slotPhrase } from '$lib/server/log.prose';
 import { sendEmail } from '$lib/server/email';
 import { EMAIL_TEMPLATES } from '$lib/server/email.templates';
 import { bookingReminder } from '$lib/server/db/reminder.schema';
-import { booking, timeBlock } from '$lib/server/db/booking.schema';
+import { booking } from '$lib/server/db/booking.schema';
 import { user } from '$lib/server/db/auth.schema';
+import { getTimeBlockHours } from '$lib/server/booking';
 import { buildBookingReminderVariables } from '$lib/server/reminder.email';
 
 export async function processReminders(): Promise<number> {
@@ -21,23 +22,22 @@ export async function processReminders(): Promise<number> {
 			username: user.username,
 			resource: booking.resource,
 			date: booking.date,
-			startHour: timeBlock.startHour,
-			endHour: timeBlock.endHour
+			timeBlockId: booking.timeBlockId
 		})
 		.from(bookingReminder)
 		.innerJoin(user, eq(bookingReminder.userId, user.id))
 		.innerJoin(booking, eq(bookingReminder.bookingId, booking.id))
-		.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 		.where(and(eq(bookingReminder.status, 'pending'), lte(bookingReminder.notifyAt, currentTime)))
 		.orderBy(bookingReminder.notifyAt)
 		.limit(50);
 
 	for (const reminder of due) {
+		const { startHour, endHour } = await getTimeBlockHours(reminder.timeBlockId);
 		const variables = buildBookingReminderVariables({
 			resource: reminder.resource,
 			date: reminder.date,
-			startHour: reminder.startHour,
-			endHour: reminder.endHour
+			startHour,
+			endHour
 		});
 
 		try {
@@ -51,7 +51,7 @@ export async function processReminders(): Promise<number> {
 				.set({ status: 'sent', sentAt: currentTime, resendId })
 				.where(eq(bookingReminder.id, reminder.id));
 			log.info(
-				`[scheduler] sent reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour, reminder.endHour)}`
+				`[scheduler] sent reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, startHour, endHour)}`
 			);
 		} catch (e) {
 			const failReason = e instanceof Error ? e.message : String(e);
@@ -60,7 +60,7 @@ export async function processReminders(): Promise<number> {
 				.set({ status: 'failed', failReason })
 				.where(eq(bookingReminder.id, reminder.id));
 			log.error(
-				`[scheduler] failed to send reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, reminder.startHour, reminder.endHour)}: ${failReason}`
+				`[scheduler] failed to send reminder to apartment ${reminder.username} for ${slotPhrase(reminder.resource, reminder.date, startHour, endHour)}: ${failReason}`
 			);
 		}
 	}

--- a/src/lib/server/reminder.ts
+++ b/src/lib/server/reminder.ts
@@ -2,7 +2,8 @@ import { CalendarDateTime, parseDate, toZoned, today } from '@internationalized/
 import { eq, and, gte, inArray } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { reminderPreference, bookingReminder } from '$lib/server/db/reminder.schema';
-import { booking, timeBlock } from '$lib/server/db/booking.schema';
+import { booking } from '$lib/server/db/booking.schema';
+import { getTimeBlockHours } from '$lib/server/booking';
 import { TIMEZONE, type Resource } from '$lib/types/bookings';
 
 export function computeNotifyAt(dateStr: string, startHour: number, offsetMinutes: number): Date {
@@ -51,10 +52,9 @@ export async function setReminderPreference(
 				.select({
 					bookingId: booking.id,
 					date: booking.date,
-					startHour: timeBlock.startHour
+					timeBlockId: booking.timeBlockId
 				})
 				.from(booking)
-				.innerJoin(timeBlock, eq(booking.timeBlockId, timeBlock.id))
 				.where(
 					and(
 						eq(booking.userId, userId),
@@ -64,7 +64,8 @@ export async function setReminderPreference(
 				);
 
 			for (const b of futureBookings) {
-				const notifyAt = computeNotifyAt(b.date, b.startHour, offsetMinutes);
+				const { startHour } = await getTimeBlockHours(b.timeBlockId);
+				const notifyAt = computeNotifyAt(b.date, startHour, offsetMinutes);
 				await tx
 					.insert(bookingReminder)
 					.values({
@@ -107,12 +108,7 @@ export async function createBookingReminders(
 	dateStr: string,
 	timeBlockId: number
 ): Promise<number> {
-	const [block] = await db
-		.select({ startHour: timeBlock.startHour })
-		.from(timeBlock)
-		.where(eq(timeBlock.id, timeBlockId));
-
-	if (!block) return 0;
+	const { startHour } = await getTimeBlockHours(timeBlockId);
 
 	const prefs = await db
 		.select({ offsetMinutes: reminderPreference.offsetMinutes })
@@ -126,7 +122,7 @@ export async function createBookingReminders(
 		);
 
 	for (const pref of prefs) {
-		const notifyAt = computeNotifyAt(dateStr, block.startHour, pref.offsetMinutes);
+		const notifyAt = computeNotifyAt(dateStr, startHour, pref.offsetMinutes);
 		await db
 			.insert(bookingReminder)
 			.values({


### PR DESCRIPTION
Closes #37.

## Summary

- `setReminderPreference`, `createBookingReminders`, and `processReminders` now select Bookings (or `bookingReminder` joined to `booking`) only and resolve `(startHour, endHour)` per row via `getTimeBlockHours`.
- Drops `innerJoin(timeBlock, ...)` from all three reminder code paths and removes the separate `SELECT` against `time_block` in `createBookingReminders`.
- Per ADR-0004, the cache covers historic rows whose `(resource, startHour)` is no longer in `TIME_BLOCKS`, so reminder emails for historic Bookings still render the correct `TIME_RANGE`.
- `computeNotifyAt` and `buildBookingReminderVariables` are unchanged — pure-function reminder tests pass untouched.
- Removed the now-redundant `@lintignore` tag on `getTimeBlockHours` since it has consumers.

## Test plan

- [x] `pnpm test` (unit + e2e)
- [x] `pnpm lint`
- [x] `pnpm check`
- [x] `pnpm knip`
- [x] Manual: enable a Reminder Preference with a future Booking → `bookingReminder` row carries the correct `notify_at`
- [x] Manual: a Booking referencing a historic `time_block_id` (hours absent from current `TIME_BLOCKS`) still produces a reminder email with the correct `TIME_RANGE`