### PR TITLE
feat(booking): move Booking Calendar live iterable into deep module

### DIFF
--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -10,7 +10,7 @@ import {
 	cancelBooking as cancelBookingDb,
 	validateBookingDate
 } from '$lib/server/booking';
-import { getBookingCalendar } from '$lib/server/booking-calendar';
+import { watchBookingCalendar } from '$lib/server/booking-calendar';
 import { bookingEvents } from '$lib/server/booking-events';
 import { createBookingReminders } from '$lib/server/reminder';
 import { TIMEZONE, RESOURCES } from '$lib/types/bookings';
@@ -29,33 +29,7 @@ export const getBookingData = query.live(
 	}),
 	async function* ({ resource }) {
 		const user = getAuthUser();
-
-		const buildPayload = () => getBookingCalendar(resource, user, now(TIMEZONE));
-
-		let pending = false;
-		let wake: (() => void) | undefined;
-
-		const unsubscribe = bookingEvents.subscribe(resource, () => {
-			pending = true;
-			wake?.();
-			wake = undefined;
-		});
-
-		try {
-			yield await buildPayload();
-
-			while (true) {
-				if (!pending) {
-					await new Promise<void>((resolve) => {
-						wake = resolve;
-					});
-				}
-				pending = false;
-				yield await buildPayload();
-			}
-		} finally {
-			unsubscribe();
-		}
+		yield* watchBookingCalendar(resource, user);
 	}
 );
 

--- a/src/lib/server/booking-calendar.spec.ts
+++ b/src/lib/server/booking-calendar.spec.ts
@@ -8,7 +8,8 @@ import { TIMEZONE, type Resource } from '$lib/types/bookings';
 import * as schema from './db/schema';
 import { booking, timeBlock, user } from './db/schema';
 import { seedTimeBlocks } from './db/seed-time-blocks';
-import { __getBookingCalendarSnapshot } from './booking-calendar';
+import { __getBookingCalendarSnapshot, __watchBookingCalendar } from './booking-calendar';
+import { bookingEvents, __listenerCount } from './booking-events';
 
 type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -461,5 +462,139 @@ describe('getBookingCalendar', () => {
 				await client.close();
 			}
 		});
+	});
+});
+
+describe('watchBookingCalendar', () => {
+	const clock = () => startOfToday;
+
+	function nextOrTimeout<T>(
+		iter: AsyncIterator<T>,
+		ms: number
+	): Promise<IteratorResult<T> | 'timeout'> {
+		return Promise.race([
+			iter.next(),
+			new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), ms))
+		]);
+	}
+
+	it('yields a fresh payload on subscribe', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await seedTimeBlocks(db);
+			await insertUser(db, me.id, 'A1001');
+
+			const iter = __watchBookingCalendar(db, 'laundry_room', me, clock);
+			try {
+				const first = await iter.next();
+				expect(first.done).toBe(false);
+				expect(first.value?.bookingCalendar).toBeDefined();
+				expect(first.value?.bookingCalendar[startStr]).toHaveLength(5);
+			} finally {
+				await iter.return?.();
+			}
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('yields a fresh payload on every bookingEvents.emit for the same resource', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await seedTimeBlocks(db);
+			await insertUser(db, me.id, 'A1001');
+			const tb7_10 = await timeBlockId(db, 'laundry_room', 7, 10);
+			const tomorrow = start.add({ days: 1 }).toString();
+
+			const iter = __watchBookingCalendar(db, 'laundry_room', me, clock);
+			try {
+				const first = await iter.next();
+				expect(first.value?.activeBooking).toBeUndefined();
+
+				const bookingId = await insertBooking(db, {
+					userId: me.id,
+					timeBlockId: tb7_10,
+					resource: 'laundry_room',
+					date: tomorrow
+				});
+				bookingEvents.emit('laundry_room');
+
+				const second = await iter.next();
+				expect(second.done).toBe(false);
+				expect(second.value?.activeBooking?.bookingId).toBe(bookingId);
+				expect(second.value?.activeBooking?.date.toString()).toBe(tomorrow);
+			} finally {
+				await iter.return?.();
+			}
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('does not yield on bookingEvents.emit for a different resource', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await seedTimeBlocks(db);
+			await insertUser(db, me.id, 'A1001');
+
+			const iter = __watchBookingCalendar(db, 'laundry_room', me, clock);
+			try {
+				await iter.next();
+
+				bookingEvents.emit('outdoor_area');
+
+				const second = await nextOrTimeout(iter, 50);
+				expect(second).toBe('timeout');
+			} finally {
+				await iter.return?.();
+			}
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('coalesces two rapid emits into a single re-yield (single-flight buffering)', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await seedTimeBlocks(db);
+			await insertUser(db, me.id, 'A1001');
+
+			const iter = __watchBookingCalendar(db, 'laundry_room', me, clock);
+			try {
+				await iter.next();
+
+				bookingEvents.emit('laundry_room');
+				bookingEvents.emit('laundry_room');
+
+				const second = await iter.next();
+				expect(second.done).toBe(false);
+
+				const third = await nextOrTimeout(iter, 50);
+				expect(third).toBe('timeout');
+			} finally {
+				await iter.return?.();
+			}
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('unsubscribes from bookingEvents when iteration terminates', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await seedTimeBlocks(db);
+			await insertUser(db, me.id, 'A1001');
+
+			const baseline = __listenerCount();
+
+			const iter = __watchBookingCalendar(db, 'laundry_room', me, clock);
+			await iter.next();
+			expect(__listenerCount()).toBe(baseline + 1);
+
+			await iter.return?.();
+			expect(__listenerCount()).toBe(baseline);
+		} finally {
+			await client.close();
+		}
 	});
 });

--- a/src/lib/server/booking-calendar.ts
+++ b/src/lib/server/booking-calendar.ts
@@ -1,9 +1,10 @@
-import { CalendarDate, type ZonedDateTime } from '@internationalized/date';
+import { CalendarDate, now, type ZonedDateTime } from '@internationalized/date';
 import { eq, and, gte, lte } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { booking, timeBlock, user } from '$lib/server/db/schema';
-import type { Resource, Slot } from '$lib/types/bookings';
+import { TIMEZONE, type Resource, type Slot } from '$lib/types/bookings';
 import { isBookingActive } from './booking';
+import { bookingEvents } from './booking-events';
 
 type BookingCalendarRow = {
 	timeBlockId: number;
@@ -152,18 +153,10 @@ function assemblePayload(
  * Snapshot read for the Booking Calendar an Apartment sees for one Facility:
  * every Slot in the Booking Window (today through today + 1 month), each
  * tagged `free` / `mine` / `other` / `past`, plus the Active Booking if any.
- */
-export async function getBookingCalendar(
-	resource: Resource,
-	caller: { id: string } | null,
-	now: ZonedDateTime
-): Promise<BookingCalendarPayload> {
-	return __getBookingCalendarSnapshot(db, resource, caller, now);
-}
-
-/**
- * Test seam: same snapshot read as `getBookingCalendar` but accepts an explicit
- * database handle so PGlite-backed integration tests can drive the read.
+ *
+ * Test seam: accepts an explicit database handle so PGlite-backed integration
+ * tests can drive the read directly. Production callers go through
+ * `watchBookingCalendar` and never see this entry point.
  */
 export async function __getBookingCalendarSnapshot(
 	database: Database,
@@ -173,4 +166,91 @@ export async function __getBookingCalendarSnapshot(
 ): Promise<BookingCalendarPayload> {
 	const rows = await readBookingCalendarRows(database, resource, now);
 	return assemblePayload(rows, caller, now);
+}
+
+/**
+ * Live read for the Booking Calendar an Apartment sees for one Facility.
+ * Yields a fresh payload on subscribe and on every relevant `bookingEvents`
+ * tick for the same resource. Single-flight buffering: events that fire
+ * during an in-flight read coalesce into one subsequent re-yield. Owns its
+ * `bookingEvents.subscribe` and unsubscribes on teardown.
+ */
+export function watchBookingCalendar(
+	resource: Resource,
+	caller: { id: string } | null
+): AsyncIterableIterator<BookingCalendarPayload> {
+	return __watchBookingCalendar(db, resource, caller, () => now(TIMEZONE));
+}
+
+/**
+ * Test seam for `watchBookingCalendar`: same iteration semantics but accepts
+ * an explicit database handle and a clock so PGlite-backed integration tests
+ * can drive the live iterable deterministically.
+ */
+export function __watchBookingCalendar(
+	database: Database,
+	resource: Resource,
+	caller: { id: string } | null,
+	getNow: () => ZonedDateTime
+): AsyncIterableIterator<BookingCalendarPayload> {
+	let pending = false;
+	let wake: (() => void) | undefined;
+	let active = true;
+	let yielded = false;
+
+	const unsubscribe = bookingEvents.subscribe(resource, () => {
+		pending = true;
+		wake?.();
+		wake = undefined;
+	});
+
+	const teardown = () => {
+		if (!active) return;
+		active = false;
+		unsubscribe();
+		wake?.();
+		wake = undefined;
+	};
+
+	const buildPayload = () => __getBookingCalendarSnapshot(database, resource, caller, getNow());
+
+	const done = (): IteratorResult<BookingCalendarPayload> => ({
+		done: true,
+		value: undefined as unknown as BookingCalendarPayload
+	});
+
+	return {
+		async next(): Promise<IteratorResult<BookingCalendarPayload>> {
+			if (!active) return done();
+
+			if (!yielded) {
+				yielded = true;
+				const value = await buildPayload();
+				if (!active) return done();
+				return { done: false, value };
+			}
+
+			if (!pending) {
+				await new Promise<void>((resolve) => {
+					wake = resolve;
+				});
+			}
+			if (!active) return done();
+			pending = false;
+			const value = await buildPayload();
+			if (!active) return done();
+			return { done: false, value };
+		},
+		async return(): Promise<IteratorResult<BookingCalendarPayload>> {
+			teardown();
+			return done();
+		},
+		async throw(err: unknown): Promise<IteratorResult<BookingCalendarPayload>> {
+			teardown();
+			throw err;
+		},
+		[Symbol.asyncIterator]() {
+			return this;
+		}
+	};
 }

--- a/src/lib/server/booking-events.ts
+++ b/src/lib/server/booking-events.ts
@@ -18,3 +18,11 @@ export const bookingEvents = {
 		return () => emitter.off(CHANGE, listener);
 	}
 };
+
+/**
+ * Test seam: returns the current number of `change` listeners on the
+ * underlying emitter so tests can assert that subscribers tear down cleanly.
+ */
+export function __listenerCount(): number {
+	return emitter.listenerCount(CHANGE);
+}


### PR DESCRIPTION
Closes #46.

## Summary

- New `watchBookingCalendar(resource, caller)` AsyncIterable in the Booking Calendar module owns the bus subscribe, the single-flight `pending`/`wake` dance, and the unsubscribe on teardown. The remote function's `getBookingData` shrinks to schema validation, `getAuthUser()`, and a `yield*` over the iterable.
- The iterable is a custom `AsyncIterableIterator` rather than an `async function*`. The original generator leaked when torn down without a pending emit (the awaited wake-promise never resolves, so the `finally` never runs, so the listener is never removed). The custom iterator's `return()` wakes the suspended `next()` synchronously and unsubscribes — which is also what makes acceptance criterion 6 testable.
- `bookingEvents` public surface is unchanged. `book` and `cancelBooking` still call `bookingEvents.emit(resource)` and `getBookingData(...).reconnect()` — ADR-0002's contract at the command boundary is preserved. `BookingPage.svelte` is untouched.
- Removed the now-unused public `getBookingCalendar` snapshot wrapper. The `__getBookingCalendarSnapshot` test seam remains.

## Test plan

- [x] `pnpm test` — 51 unit + 36 e2e pass, including the existing `live-updates.e2e.ts` coverage.
- [x] New unit tests in `booking-calendar.spec.ts`:
  - yield-on-subscribe
  - yield-on-relevant-emit
  - no-yield-on-other-resource-emit (verified via timeout race)
  - single-flight buffering: two rapid emits → one re-yield, no third yield queued
  - unsubscribe-on-teardown: listener count returns to baseline after `iter.return()`
- [x] `pnpm check`, `pnpm knip`, `pnpm lint` clean.