### PR TITLE
fix(reminder): skip emails whose window has already closed at booking time

### DIFF
--- a/src/lib/api/admin.remote.ts
+++ b/src/lib/api/admin.remote.ts
@@ -3,6 +3,7 @@ import { error, invalid } from '@sveltejs/kit';
 import { getRequestEvent, query, command, form } from '$app/server';
 import { eq } from 'drizzle-orm';
 import { APIError } from 'better-auth/api';
+import { now } from '@internationalized/date';
 import { env } from '$env/dynamic/private';
 import { auth, requireAdmin } from '$lib/server/auth';
 import { apartmentSchema } from '$lib/server/auth.config';
@@ -12,7 +13,7 @@ import { reminderPreference } from '$lib/server/db/reminder.schema';
 import { calendarToken } from '$lib/server/db/calendar.schema';
 import { getReminderPreferences, setReminderPreference } from '$lib/server/reminder';
 import { getExistingToken, createToken, regenerateToken, deleteToken } from '$lib/server/calendar';
-import { RESOURCES } from '$lib/types/bookings';
+import { TIMEZONE, RESOURCES } from '$lib/types/bookings';
 import { log } from '$lib/server/log';
 
 async function findByUsername(username: string) {
@@ -183,7 +184,7 @@ export const setUserReminderPreference = command(
 		const target = await findByUsername(username);
 		if (!target) error(404, 'Hittade inte lägenheten');
 
-		await setReminderPreference(target.id, resource, offsetMinutes, enabled);
+		await setReminderPreference(target.id, resource, offsetMinutes, enabled, now(TIMEZONE));
 		const verb = enabled ? 'enabled' : 'disabled';
 		log.info(
 			`[admin] apartment ${self.username} ${verb} ${offsetMinutes}-minute reminders for the ${resource} for apartment ${username}`

--- a/src/lib/api/booking.remote.ts
+++ b/src/lib/api/booking.remote.ts
@@ -85,7 +85,8 @@ export const book = command(
 				user.id,
 				resource,
 				date.toString(),
-				timeBlockId
+				timeBlockId,
+				now(TIMEZONE)
 			);
 			if (count > 0) {
 				log.info(

--- a/src/lib/api/reminder.remote.ts
+++ b/src/lib/api/reminder.remote.ts
@@ -1,9 +1,10 @@
 import * as v from 'valibot';
+import { now } from '@internationalized/date';
 import { query, command } from '$app/server';
 import { requireAuth } from '$lib/server/auth';
 import { log } from '$lib/server/log';
 import { getReminderPreferences, setReminderPreference } from '$lib/server/reminder';
-import { RESOURCES } from '$lib/types/bookings';
+import { TIMEZONE, RESOURCES } from '$lib/types/bookings';
 
 export const getPreferences = query(async () => {
 	const user = requireAuth();
@@ -18,7 +19,7 @@ export const togglePreference = command(
 	}),
 	async ({ resource, offsetMinutes, enabled }) => {
 		const user = requireAuth();
-		await setReminderPreference(user.id, resource, offsetMinutes, enabled);
+		await setReminderPreference(user.id, resource, offsetMinutes, enabled, now(TIMEZONE));
 		const verb = enabled ? 'enabled' : 'disabled';
 		log.info(
 			`[reminder] apartment ${user.username} ${verb} ${offsetMinutes}-minute reminders for the ${resource}`

--- a/src/lib/server/reminder.spec.ts
+++ b/src/lib/server/reminder.spec.ts
@@ -1,7 +1,57 @@
 import { describe, it, expect } from 'vitest';
-import { CalendarDate } from '@internationalized/date';
-import { computeNotifyAt } from './reminder';
+import { CalendarDate, CalendarDateTime, toZoned } from '@internationalized/date';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import { pushSchema } from 'drizzle-kit/api';
+import { and, eq } from 'drizzle-orm';
+import { TIMEZONE, type Resource } from '$lib/types/bookings';
+import * as schema from './db/schema';
+import { booking, timeBlock, user } from './db/schema';
+import { reminderPreference, bookingReminder } from './db/reminder.schema';
+import { seedTimeBlocks } from './db/seed-time-blocks';
+import { computeNotifyAt, createBookingReminders, setReminderPreference } from './reminder';
 import { buildBookingReminderVariables } from './reminder.email';
+
+type TestDb = ReturnType<typeof drizzle<typeof schema>>;
+
+async function makeTestDb(): Promise<{ client: PGlite; db: TestDb }> {
+	const client = new PGlite();
+	const db = drizzle(client, { schema });
+	const pushed = await pushSchema(schema, db as unknown as Parameters<typeof pushSchema>[1]);
+	await pushed.apply();
+	await seedTimeBlocks(db);
+	return { client, db };
+}
+
+async function insertUser(db: TestDb, id: string, username: string): Promise<void> {
+	await db.insert(user).values({
+		id,
+		name: username,
+		email: `${username}@example.com`,
+		username,
+		displayUsername: username
+	});
+}
+
+async function timeBlockId(
+	db: TestDb,
+	resource: Resource,
+	startHour: number,
+	endHour: number
+): Promise<number> {
+	const [row] = await db
+		.select({ id: timeBlock.id })
+		.from(timeBlock)
+		.where(
+			and(
+				eq(timeBlock.resource, resource),
+				eq(timeBlock.startHour, startHour),
+				eq(timeBlock.endHour, endHour)
+			)
+		);
+	if (!row) throw new Error(`no time_block for ${resource} ${startHour}-${endHour}`);
+	return row.id;
+}
 
 describe('computeNotifyAt', () => {
 	it('subtracts 60 minutes from booking start', () => {
@@ -103,5 +153,223 @@ describe('buildBookingReminderVariables', () => {
 			referenceDate: ref
 		});
 		expect(vars.TIME_RANGE).toBe('07:00\u201310:00');
+	});
+});
+
+describe('createBookingReminders', () => {
+	const userId = 'apt-A1001';
+	const username = 'A1001';
+
+	it('does not insert a reminder when notifyAt is at or before now', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await insertUser(db, userId, username);
+			const tbId = await timeBlockId(db, 'laundry_room', 10, 13);
+			// Apartment has the 60-minute reminder enabled.
+			await db.insert(reminderPreference).values({
+				userId,
+				resource: 'laundry_room',
+				offsetMinutes: 60,
+				enabled: true
+			});
+			// Apartment books today's 10\u201313 Slot at 09:30 \u2014 only 30 min before start,
+			// well inside the 60-minute reminder window. The reminder is moot.
+			const dateStr = '2026-05-04';
+			const [b] = await db
+				.insert(booking)
+				.values({ userId, timeBlockId: tbId, resource: 'laundry_room', date: dateStr })
+				.returning({ id: booking.id });
+			const now = toZoned(new CalendarDateTime(2026, 5, 4, 9, 30), TIMEZONE);
+
+			const scheduled = await createBookingReminders(
+				b.id,
+				userId,
+				'laundry_room',
+				dateStr,
+				tbId,
+				now,
+				db
+			);
+
+			expect(scheduled).toBe(0);
+			const rows = await db
+				.select()
+				.from(bookingReminder)
+				.where(eq(bookingReminder.userId, userId));
+			expect(rows).toEqual([]);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('does not insert a reminder when the slot has already started', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await insertUser(db, userId, username);
+			const tbId = await timeBlockId(db, 'laundry_room', 10, 13);
+			await db.insert(reminderPreference).values({
+				userId,
+				resource: 'laundry_room',
+				offsetMinutes: 1440,
+				enabled: true
+			});
+			// Booking the 10\u201313 Slot at 11:30 \u2014 slot is already in progress.
+			const dateStr = '2026-05-04';
+			const [b] = await db
+				.insert(booking)
+				.values({ userId, timeBlockId: tbId, resource: 'laundry_room', date: dateStr })
+				.returning({ id: booking.id });
+			const now = toZoned(new CalendarDateTime(2026, 5, 4, 11, 30), TIMEZONE);
+
+			const scheduled = await createBookingReminders(
+				b.id,
+				userId,
+				'laundry_room',
+				dateStr,
+				tbId,
+				now,
+				db
+			);
+
+			expect(scheduled).toBe(0);
+			const rows = await db.select().from(bookingReminder);
+			expect(rows).toEqual([]);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('inserts a reminder when notifyAt is strictly in the future', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await insertUser(db, userId, username);
+			const tbId = await timeBlockId(db, 'laundry_room', 16, 19);
+			await db.insert(reminderPreference).values({
+				userId,
+				resource: 'laundry_room',
+				offsetMinutes: 60,
+				enabled: true
+			});
+			// Booking today's 16\u201319 Slot at 09:30 \u2014 reminder fires at 15:00, well
+			// in the future.
+			const dateStr = '2026-05-04';
+			const [b] = await db
+				.insert(booking)
+				.values({ userId, timeBlockId: tbId, resource: 'laundry_room', date: dateStr })
+				.returning({ id: booking.id });
+			const now = toZoned(new CalendarDateTime(2026, 5, 4, 9, 30), TIMEZONE);
+
+			const scheduled = await createBookingReminders(
+				b.id,
+				userId,
+				'laundry_room',
+				dateStr,
+				tbId,
+				now,
+				db
+			);
+
+			expect(scheduled).toBe(1);
+			const rows = await db
+				.select()
+				.from(bookingReminder)
+				.where(eq(bookingReminder.bookingId, b.id));
+			expect(rows).toHaveLength(1);
+			expect(rows[0].status).toBe('pending');
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('inserts only the offsets whose window is still open', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await insertUser(db, userId, username);
+			const tbId = await timeBlockId(db, 'laundry_room', 10, 13);
+			// Apartment has both a 60-minute and a 1440-minute (24h) reminder enabled.
+			await db.insert(reminderPreference).values([
+				{ userId, resource: 'laundry_room', offsetMinutes: 60, enabled: true },
+				{ userId, resource: 'laundry_room', offsetMinutes: 1440, enabled: true }
+			]);
+			// Booking tomorrow's 10\u201313 Slot today at 11:00. Tomorrow 10:00 minus
+			// 60 min = tomorrow 09:00 \u2192 still in the future. Tomorrow 10:00 minus
+			// 1440 min = today 10:00 \u2192 already in the past.
+			const dateStr = '2026-05-05';
+			const [b] = await db
+				.insert(booking)
+				.values({ userId, timeBlockId: tbId, resource: 'laundry_room', date: dateStr })
+				.returning({ id: booking.id });
+			const now = toZoned(new CalendarDateTime(2026, 5, 4, 11, 0), TIMEZONE);
+
+			const scheduled = await createBookingReminders(
+				b.id,
+				userId,
+				'laundry_room',
+				dateStr,
+				tbId,
+				now,
+				db
+			);
+
+			expect(scheduled).toBe(1);
+			const rows = await db
+				.select({ offsetMinutes: bookingReminder.offsetMinutes })
+				.from(bookingReminder)
+				.where(eq(bookingReminder.bookingId, b.id));
+			expect(rows).toEqual([{ offsetMinutes: 60 }]);
+		} finally {
+			await client.close();
+		}
+	});
+});
+
+describe('setReminderPreference enabling', () => {
+	const userId = 'apt-A1001';
+	const username = 'A1001';
+
+	it('does not schedule reminders for future bookings whose window has already closed', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await insertUser(db, userId, username);
+			const tbId = await timeBlockId(db, 'laundry_room', 10, 13);
+			// Apartment already has a Booking for today's 10\u201313 Slot.
+			const dateStr = '2026-05-04';
+			await db
+				.insert(booking)
+				.values({ userId, timeBlockId: tbId, resource: 'laundry_room', date: dateStr });
+			// At 09:30, apartment toggles 60-minute reminders on. Booking starts in
+			// 30 min, inside the window \u2014 no reminder should be scheduled.
+			const now = toZoned(new CalendarDateTime(2026, 5, 4, 9, 30), TIMEZONE);
+
+			const scheduled = await setReminderPreference(userId, 'laundry_room', 60, true, now, db);
+
+			expect(scheduled).toBe(0);
+			const rows = await db.select().from(bookingReminder);
+			expect(rows).toEqual([]);
+		} finally {
+			await client.close();
+		}
+	});
+
+	it('schedules reminders for future bookings whose window is still open', async () => {
+		const { client, db } = await makeTestDb();
+		try {
+			await insertUser(db, userId, username);
+			const tbId = await timeBlockId(db, 'laundry_room', 16, 19);
+			const dateStr = '2026-05-04';
+			await db
+				.insert(booking)
+				.values({ userId, timeBlockId: tbId, resource: 'laundry_room', date: dateStr });
+			const now = toZoned(new CalendarDateTime(2026, 5, 4, 9, 30), TIMEZONE);
+
+			const scheduled = await setReminderPreference(userId, 'laundry_room', 60, true, now, db);
+
+			expect(scheduled).toBe(1);
+			const rows = await db.select().from(bookingReminder);
+			expect(rows).toHaveLength(1);
+			expect(rows[0].offsetMinutes).toBe(60);
+		} finally {
+			await client.close();
+		}
 	});
 });

--- a/src/lib/server/reminder.ts
+++ b/src/lib/server/reminder.ts
@@ -1,10 +1,26 @@
-import { CalendarDateTime, parseDate, toZoned, today } from '@internationalized/date';
+import { CalendarDateTime, type ZonedDateTime, parseDate, toZoned } from '@internationalized/date';
 import { eq, and, gte, inArray } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { reminderPreference, bookingReminder } from '$lib/server/db/reminder.schema';
-import { booking } from '$lib/server/db/booking.schema';
-import { getTimeBlockHours } from '$lib/server/booking';
+import { booking, timeBlock } from '$lib/server/db/booking.schema';
 import { TIMEZONE, type Resource } from '$lib/types/bookings';
+
+type Database = typeof db;
+// A drizzle handle that exposes `.select()` — both the top-level `db` and a
+// transaction handle (`tx`) qualify. PGlite serializes all queries through one
+// connection, so when we are inside `database.transaction(...)` we must use
+// `tx`, never the parent `database` (the latter would deadlock).
+type Selectable = Pick<Database, 'select'>;
+
+async function lookupStartHour(database: Selectable, timeBlockId: number): Promise<number> {
+	const [row] = await database
+		.select({ startHour: timeBlock.startHour })
+		.from(timeBlock)
+		.where(eq(timeBlock.id, timeBlockId))
+		.limit(1);
+	if (!row) throw new Error(`unknown time block id ${timeBlockId}`);
+	return row.startHour;
+}
 
 export function computeNotifyAt(dateStr: string, startHour: number, offsetMinutes: number): Date {
 	const date = parseDate(dateStr);
@@ -30,11 +46,15 @@ export async function setReminderPreference(
 	userId: string,
 	resource: Resource,
 	offsetMinutes: number,
-	enabled: boolean
-) {
-	const todayStr = today(TIMEZONE).toString();
+	enabled: boolean,
+	now: ZonedDateTime,
+	database: typeof db = db
+): Promise<number> {
+	const todayStr = `${now.year}-${String(now.month).padStart(2, '0')}-${String(now.day).padStart(2, '0')}`;
+	const nowMs = now.toDate().getTime();
+	let scheduled = 0;
 
-	await db.transaction(async (tx) => {
+	await database.transaction(async (tx) => {
 		await tx
 			.insert(reminderPreference)
 			.values({ userId, resource, enabled, offsetMinutes })
@@ -64,9 +84,13 @@ export async function setReminderPreference(
 				);
 
 			for (const b of futureBookings) {
-				const { startHour } = await getTimeBlockHours(b.timeBlockId);
+				const startHour = await lookupStartHour(tx, b.timeBlockId);
 				const notifyAt = computeNotifyAt(b.date, startHour, offsetMinutes);
-				await tx
+				// Skip Bookings whose reminder window has already closed — sending a
+				// reminder for a Slot that starts imminently (or has started) is noise,
+				// not a reminder. The actor just made or held the Booking on purpose.
+				if (notifyAt.getTime() <= nowMs) continue;
+				const inserted = await tx
 					.insert(bookingReminder)
 					.values({
 						bookingId: b.bookingId,
@@ -74,7 +98,9 @@ export async function setReminderPreference(
 						offsetMinutes,
 						notifyAt
 					})
-					.onConflictDoNothing();
+					.onConflictDoNothing()
+					.returning();
+				scheduled += inserted.length;
 			}
 		} else {
 			const futureBookingIds = tx
@@ -99,6 +125,8 @@ export async function setReminderPreference(
 				);
 		}
 	});
+
+	return scheduled;
 }
 
 export async function createBookingReminders(
@@ -106,11 +134,14 @@ export async function createBookingReminders(
 	userId: string,
 	resource: Resource,
 	dateStr: string,
-	timeBlockId: number
+	timeBlockId: number,
+	now: ZonedDateTime,
+	database: typeof db = db
 ): Promise<number> {
-	const { startHour } = await getTimeBlockHours(timeBlockId);
+	const startHour = await lookupStartHour(database, timeBlockId);
+	const nowMs = now.toDate().getTime();
 
-	const prefs = await db
+	const prefs = await database
 		.select({ offsetMinutes: reminderPreference.offsetMinutes })
 		.from(reminderPreference)
 		.where(
@@ -121,9 +152,13 @@ export async function createBookingReminders(
 			)
 		);
 
+	let scheduled = 0;
 	for (const pref of prefs) {
 		const notifyAt = computeNotifyAt(dateStr, startHour, pref.offsetMinutes);
-		await db
+		// Skip preferences whose reminder window has already closed — see
+		// setReminderPreference for rationale.
+		if (notifyAt.getTime() <= nowMs) continue;
+		const inserted = await database
 			.insert(bookingReminder)
 			.values({
 				bookingId,
@@ -131,8 +166,10 @@ export async function createBookingReminders(
 				offsetMinutes: pref.offsetMinutes,
 				notifyAt
 			})
-			.onConflictDoNothing();
+			.onConflictDoNothing()
+			.returning();
+		scheduled += inserted.length;
 	}
 
-	return prefs.length;
+	return scheduled;
 }


### PR DESCRIPTION
## Summary

- Booking a Slot already inside its reminder window (or while the Slot is in progress) caused a reminder email to fire within ≤60s of the click. Same shape on the Reminder Preference toggle: enabling a 24h reminder while holding a Booking that starts in 3 hours triggered an immediate send.
- Root cause: `createBookingReminders` and `setReminderPreference` (`src/lib/server/reminder.ts`) inserted `pending` rows whose `notifyAt` could already be `<= now`. The scheduler treats *any* pending row with `notifyAt <= now` as due.
- Fix: skip the insert when `notifyAt <= now` in both functions. Threaded `now: ZonedDateTime` through (matching `bookSlot`/`cancelBooking`) and made `db` injectable (matching `__getBookingCalendarSnapshot`) so the regression tests can drive the functions against PGlite. Time-block lookup now goes via the injected handle, mirroring `booking-calendar.ts`.

## Test plan

- [x] 6 new PGlite-backed tests in `reminder.spec.ts`; verified all 4 of the "skip" assertions fail without the guard.
- [x] `pnpm check` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 57 unit + 36 e2e green