### PR TITLE
test(ci): bump server testTimeout to 15s for PGlite cold-start

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,7 +81,10 @@ export default defineConfig({
 					include: ['src/**/*.{test,spec}.{js,ts}'],
 					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}'],
 					setupFiles: ['src/lib/server/test-setup.ts'],
-					env: { LOG_LEVEL: 'error' }
+					env: { LOG_LEVEL: 'error' },
+					// PGlite cold-start in CI eats ~4–5s on the first makeTestDb() call
+					// in each spec file; the default 5000ms is too tight.
+					testTimeout: 15000
 				}
 			}
 		]


### PR DESCRIPTION
The default 5000ms left no headroom — the first makeTestDb() in each spec file regularly costs 4–5s in CI, and a new reminder test crossed the line.