### PR TITLE
refactor(reminder): route Time Block lookups through getTimeBlockHours (#52)

### DIFF
--- a/src/lib/server/booking.ts
+++ b/src/lib/server/booking.ts
@@ -71,8 +71,29 @@ export async function __buildTimeBlockMap(
  * lazy module-level cache. Per ADR-0004 the cache covers historic rows
  * (whose `(resource, startHour)` may no longer be in `TIME_BLOCKS`), which a
  * `findTimeBlock` constant lookup cannot.
+ *
+ * The optional `database` handle bypasses the cache and queries it directly —
+ * a test seam for PGlite-backed tests that need lookups against an isolated
+ * handle. A drizzle handle that exposes `.select()` qualifies (top-level `db`
+ * or a transaction `tx`).
  */
-export async function getTimeBlockHours(timeBlockId: number): Promise<TimeBlockHours> {
+export async function getTimeBlockHours(
+	timeBlockId: number,
+	database?: Pick<typeof db, 'select'>
+): Promise<TimeBlockHours> {
+	if (database) {
+		const [row] = await database
+			.select({
+				resource: timeBlock.resource,
+				startHour: timeBlock.startHour,
+				endHour: timeBlock.endHour
+			})
+			.from(timeBlock)
+			.where(eq(timeBlock.id, timeBlockId))
+			.limit(1);
+		if (!row) throw new Error(`unknown time block id ${timeBlockId}`);
+		return { resource: row.resource, startHour: row.startHour, endHour: row.endHour };
+	}
 	timeBlockCachePromise ??= __buildTimeBlockMap(db);
 	const map = await timeBlockCachePromise;
 	const hours = map.get(timeBlockId);

--- a/src/lib/server/reminder.spec.ts
+++ b/src/lib/server/reminder.spec.ts
@@ -9,7 +9,7 @@ import * as schema from './db/schema';
 import { booking, timeBlock, user } from './db/schema';
 import { reminderPreference, bookingReminder } from './db/reminder.schema';
 import { seedTimeBlocks } from './db/seed-time-blocks';
-import { computeNotifyAt, createBookingReminders, setReminderPreference } from './reminder';
+import { __computeNotifyAt, createBookingReminders, setReminderPreference } from './reminder';
 
 type TestDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -52,15 +52,15 @@ async function timeBlockId(
 	return row.id;
 }
 
-describe('computeNotifyAt', () => {
+describe('__computeNotifyAt', () => {
 	it('subtracts 60 minutes from booking start', () => {
-		const result = computeNotifyAt('2026-04-15', 10, 60);
+		const result = __computeNotifyAt('2026-04-15', 10, 60);
 		// 2026-04-15 10:00 Stockholm (CEST, UTC+2) = 08:00 UTC → minus 60 min = 07:00 UTC
 		expect(result.toISOString()).toBe('2026-04-15T07:00:00.000Z');
 	});
 
 	it('subtracts 1440 minutes (24 hours) crossing day boundary', () => {
-		const result = computeNotifyAt('2026-04-15', 7, 1440);
+		const result = __computeNotifyAt('2026-04-15', 7, 1440);
 		// 2026-04-15 07:00 Stockholm (CEST, UTC+2) = 05:00 UTC → minus 24h = 2026-04-14 05:00 UTC
 		expect(result.toISOString()).toBe('2026-04-14T05:00:00.000Z');
 	});
@@ -69,7 +69,7 @@ describe('computeNotifyAt', () => {
 		// Sweden switches CET→CEST on 2026-03-29 at 02:00
 		// 2026-03-29 07:00 Stockholm is CEST (UTC+2) = 05:00 UTC
 		// Minus 60 min = 06:00 Stockholm = 04:00 UTC (still CEST)
-		const result = computeNotifyAt('2026-03-29', 7, 60);
+		const result = __computeNotifyAt('2026-03-29', 7, 60);
 		expect(result.toISOString()).toBe('2026-03-29T04:00:00.000Z');
 	});
 
@@ -77,7 +77,7 @@ describe('computeNotifyAt', () => {
 		// 2026-03-29 07:00 Stockholm (CEST, UTC+2) = 05:00 UTC
 		// Minus 1440 absolute minutes = 2026-03-28 05:00 UTC = 06:00 CET
 		// (24 real hours before, not wall-clock hours)
-		const result = computeNotifyAt('2026-03-29', 7, 1440);
+		const result = __computeNotifyAt('2026-03-29', 7, 1440);
 		expect(result.toISOString()).toBe('2026-03-28T05:00:00.000Z');
 	});
 });

--- a/src/lib/server/reminder.ts
+++ b/src/lib/server/reminder.ts
@@ -2,27 +2,11 @@ import { CalendarDateTime, type ZonedDateTime, parseDate, toZoned } from '@inter
 import { eq, and, gte, inArray } from 'drizzle-orm';
 import { db } from '$lib/server/db';
 import { reminderPreference, bookingReminder } from '$lib/server/db/reminder.schema';
-import { booking, timeBlock } from '$lib/server/db/booking.schema';
+import { booking } from '$lib/server/db/booking.schema';
+import { getTimeBlockHours } from '$lib/server/booking';
 import { TIMEZONE, type Resource } from '$lib/types/bookings';
 
-type Database = typeof db;
-// A drizzle handle that exposes `.select()` — both the top-level `db` and a
-// transaction handle (`tx`) qualify. PGlite serializes all queries through one
-// connection, so when we are inside `database.transaction(...)` we must use
-// `tx`, never the parent `database` (the latter would deadlock).
-type Selectable = Pick<Database, 'select'>;
-
-async function lookupStartHour(database: Selectable, timeBlockId: number): Promise<number> {
-	const [row] = await database
-		.select({ startHour: timeBlock.startHour })
-		.from(timeBlock)
-		.where(eq(timeBlock.id, timeBlockId))
-		.limit(1);
-	if (!row) throw new Error(`unknown time block id ${timeBlockId}`);
-	return row.startHour;
-}
-
-export function computeNotifyAt(dateStr: string, startHour: number, offsetMinutes: number): Date {
+export function __computeNotifyAt(dateStr: string, startHour: number, offsetMinutes: number): Date {
 	const date = parseDate(dateStr);
 	const bookingStart = new CalendarDateTime(date.year, date.month, date.day, startHour);
 	const zoned = toZoned(bookingStart, TIMEZONE);
@@ -84,8 +68,8 @@ export async function setReminderPreference(
 				);
 
 			for (const b of futureBookings) {
-				const startHour = await lookupStartHour(tx, b.timeBlockId);
-				const notifyAt = computeNotifyAt(b.date, startHour, offsetMinutes);
+				const { startHour } = await getTimeBlockHours(b.timeBlockId, tx);
+				const notifyAt = __computeNotifyAt(b.date, startHour, offsetMinutes);
 				// Skip Bookings whose reminder window has already closed — sending a
 				// reminder for a Slot that starts imminently (or has started) is noise,
 				// not a reminder. The actor just made or held the Booking on purpose.
@@ -138,7 +122,7 @@ export async function createBookingReminders(
 	now: ZonedDateTime,
 	database: typeof db = db
 ): Promise<number> {
-	const startHour = await lookupStartHour(database, timeBlockId);
+	const { startHour } = await getTimeBlockHours(timeBlockId, database);
 	const nowMs = now.toDate().getTime();
 
 	const prefs = await database
@@ -154,7 +138,7 @@ export async function createBookingReminders(
 
 	let scheduled = 0;
 	for (const pref of prefs) {
-		const notifyAt = computeNotifyAt(dateStr, startHour, pref.offsetMinutes);
+		const notifyAt = __computeNotifyAt(dateStr, startHour, pref.offsetMinutes);
 		// Skip preferences whose reminder window has already closed — see
 		// setReminderPreference for rationale.
 		if (notifyAt.getTime() <= nowMs) continue;


### PR DESCRIPTION
Closes #52.

## Summary
- Widens `getTimeBlockHours(timeBlockId, database?)` in `booking.ts` — when a handle is passed, it bypasses the module cache and queries that handle directly. Production callers (`bookSlot`, `generateCalendarFeed`, `processReminders`) keep their no-handle, cached call shape.
- Deletes `lookupStartHour` from `reminder.ts`. `setReminderPreference` and `createBookingReminders` now resolve a Booking's hours via the canonical interface (passing their `tx` / `database` through), satisfying ADR-0004.
- Renames `computeNotifyAt` → `__computeNotifyAt` (test-seam convention). Spec import updated; DST / 24h-offset / spring-forward assertions are verbatim.

Behaviourally a no-op: same Reminders scheduled, same `notify_at` values.

## Test plan
- [x] `pnpm test` — 57 unit + 36 E2E pass
- [x] `pnpm check` — 0 errors / warnings
- [x] `pnpm lint` clean
- [x] `pnpm knip` clean