### PR TITLE
style(calendar): clarify day & nav-button color semantics

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,6 +21,7 @@ Use CSS custom properties throughout. Warm neutrals with a structural green and 
 	--color-text-primary: #2c2a25; /* warm near-black — body text */
 	--color-text-secondary: #6b6560; /* warm gray — supporting text, metadata */
 	--color-text-muted: #9c9590; /* stone — captions, timestamps */
+	--color-text-disabled: #c4bdb0; /* faded stone — disabled controls & out-of-range calendar days */
 
 	/* accent (background/structural use only — never as text color) */
 	--color-accent: #4a6741; /* muted forest green — navbar, buttons, filled slots */
@@ -201,6 +202,19 @@ Focus rings use green — this is a structural indicator, not text color.
 - Terracotta distinguishes "mine" from "others" at a glance
 - Slot buttons show only time range (e.g. "10–16"), no action labels
 - Use `--radius-sm` (3px), no shadow
+
+### Calendar
+
+The booking calendar styles days on a single axis — **bookable vs. not** — never on the calendar-month boundary. The valid range (`today … today + 1 month`) straddles two months, so a bookable day looks identical whether it belongs to the visible month or spills in from the adjacent one.
+
+| State                                                              | Treatment                                                                |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| In range (bookable, incl. fully-booked — still selectable to view) | `--color-text-primary` number + slot dots, subtle `--color-bg-alt` hover |
+| Out of range (before today, past max, or grid filler)              | `--color-text-disabled` number, no dots, no hover, `cursor-not-allowed`  |
+
+- The month-spillover days from the previous/next month are **not** given a distinct "muted" shade — they follow the same bookable/disabled rule as everything else.
+- Prev/next month chevrons share the same disabled treatment: `--color-text-disabled` + `cursor-not-allowed` when navigation is blocked at the range edge. Enabled chevrons are `--color-text-primary`.
+- `--color-text-disabled` is the single shared "inert" color across dead days and disabled chevrons.
 
 ---
 

--- a/src/lib/components/Calendar.svelte
+++ b/src/lib/components/Calendar.svelte
@@ -42,7 +42,8 @@
 		{#snippet children({ months, weekdays })}
 			<Calendar.Header class="flex items-center justify-center gap-1 pb-2">
 				<Calendar.PrevButton
-					class="inline-flex size-8 items-center justify-center transition-colors duration-120 hover:bg-bg-alt"
+					class="inline-flex size-8 items-center justify-center transition-colors duration-120 hover:bg-bg-alt
+						data-disabled:cursor-not-allowed data-disabled:text-text-disabled data-disabled:hover:bg-transparent"
 				>
 					&lt;
 				</Calendar.PrevButton>
@@ -52,7 +53,8 @@
 				</Calendar.Heading>
 
 				<Calendar.NextButton
-					class="inline-flex size-8 items-center justify-center transition-colors duration-120 hover:bg-bg-alt"
+					class="inline-flex size-8 items-center justify-center transition-colors duration-120 hover:bg-bg-alt
+						data-disabled:cursor-not-allowed data-disabled:text-text-disabled data-disabled:hover:bg-transparent"
 				>
 					&gt;
 				</Calendar.NextButton>
@@ -78,8 +80,8 @@
 										<Calendar.Day
 											class="inline-flex h-12 w-full flex-col items-center justify-center py-1 text-sm
 												hover:bg-bg-alt
-												data-disabled:cursor-not-allowed data-disabled:text-border data-disabled:hover:bg-transparent
-												data-outside-month:text-text-muted data-selected:ring-2 data-selected:ring-text-primary/20 data-selected:ring-inset
+												data-disabled:cursor-not-allowed data-disabled:text-text-disabled data-disabled:hover:bg-transparent
+												data-selected:ring-2 data-selected:ring-text-primary/20 data-selected:ring-inset
 												data-today:font-semibold sm:py-2.5"
 										>
 											{day.day}

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -12,6 +12,7 @@
 	--color-text-primary: #2c2a25;
 	--color-text-secondary: #6b6560;
 	--color-text-muted: #9c9590;
+	--color-text-disabled: #c4bdb0;
 
 	/* Accent (backgrounds/structural only — never as text color) */
 	--color-accent: #4a6741;


### PR DESCRIPTION
## What

Reworks the booking calendar's color semantics so it styles days on a single **bookable vs. not-bookable** axis, rather than on the calendar-month boundary. Addresses two confusing states visible in the current UI:

1. **Disabled month chevrons had no disabled styling.** `<` (at the current month) and `>` (at the max month) were functionally disabled by bits-ui but looked fully active and still lit up on hover.
2. **Confusing shades for adjacent-month days.** Spillover days from the prev/next month used a distinct muted shade, so an in-range day like 1 Jul (shown in the June view) looked different from a current-month bookable day, while out-of-range filler days used yet another shade.

## Approach

The valid range (`today … today + 1 month`) straddles two calendar months, so "which month" is an implementation artifact — only "can I book this" matters to a resident.

| State | Treatment |
| ----- | --------- |
| In range (bookable, incl. fully-booked — still selectable) | `text-primary` number + slot dots, `bg-alt` hover |
| Out of range (before today, past max, grid filler) | new `text-disabled` number, no dots, no hover, `cursor-not-allowed` |

- New shared `--color-text-disabled: #c4bdb0` token (between `text-muted` and `border`) — one "inert" color for both dead days and disabled chevrons.
- Disabled chevrons get the same `text-disabled` + `cursor-not-allowed` + no-hover treatment.
- Removed the `data-outside-month` muted shade entirely.

## Scope

- **In:** day text colors, disabled-day state, disabled chevrons, the new token, `DESIGN.md` docs.
- **Out:** slot dots (governed by a separate `DESIGN.md` rule).

## Verification

- `pnpm test` — 55 unit + 36 E2E, all green. Tests key off bits-ui `data-*` attributes (preserved), not Tailwind classes; `booking.e2e.ts` already asserts the out-of-range `data-disabled` state we now style.
- Manual visual pass at both range-edge months (June `<` off, July `>` off; spillover days faint, no dots, not clickable).

🤖 Design stress-tested via /grill-me before implementation.